### PR TITLE
Support inner shadow and one-side border

### DIFF
--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -147,7 +147,11 @@ export default async function nodeToSketchLayers(node) {
     style.addBorder({color: borderColor, thickness: parseInt(borderWidth, 10)});
 
     if (boxShadow !== DEFAULT_VALUES.boxShadow) {
-      style.addShadow(shadowStringToObject(boxShadow));
+      if (boxShadow.indexOf('inset') !== -1) {
+        style.addInnerShadow(shadowStringToObject(boxShadow));
+      } else {
+        style.addShadow(shadowStringToObject(boxShadow));
+      }
     }
 
     leaf.setStyle(style);

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -14,7 +14,7 @@ const DEFAULT_VALUES = {
 
 function shadowStringToObject(shadowStr) {
   let shadowObj = {};
-  const matches = shadowStr.match(/^([a-z0-9#., ()]+) ([0-9.]+)px ([0-9.]+)px ([0-9.]+)px ([0-9.]+)px$/i);
+  const matches = shadowStr.match(/^([a-z0-9#., ()]+) ([-]?[0-9.]+)px ([-]?[0-9.]+)px ([-]?[0-9.]+)px ([-]?[0-9.]+)px/i);
 
   if (matches && matches.length === 6) {
     shadowObj = {

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -165,13 +165,22 @@ export default async function nodeToSketchLayers(node) {
       }
     }
 
+    // support for one-side borders (using inner shadow because Sketch doesn't support that)
     if (borderWidth.indexOf(' ') === -1) {
       style.addBorder({color: borderColor, thickness: parseInt(borderWidth, 10)});
     } else {
-      if (borderTopWidth !== '0px') style.addInnerShadow(shadowStringToObject(borderTopColor + ' 0px ' + borderTopWidth + ' 0px 0px inset'));
-      if (borderRightWidth !== '0px') style.addInnerShadow(shadowStringToObject(borderRightColor + ' -' + borderRightWidth + ' 0px 0px 0px inset'));
-      if (borderBottomWidth !== '0px') style.addInnerShadow(shadowStringToObject(borderBottomColor + ' 0px -' + borderBottomWidth + ' 0px 0px inset'));
-      if (borderLeftWidth !== '0px') style.addInnerShadow(shadowStringToObject(borderLeftColor + ' ' + borderLeftWidth + ' 0px 0px 0px inset'));
+      if (borderTopWidth !== '0px') {
+        style.addInnerShadow(shadowStringToObject(borderTopColor + ' 0px ' + borderTopWidth + ' 0px 0px inset'));
+      }
+      if (borderRightWidth !== '0px') {
+        style.addInnerShadow(shadowStringToObject(borderRightColor + ' -' + borderRightWidth + ' 0px 0px 0px inset'));
+      }
+      if (borderBottomWidth !== '0px') {
+        style.addInnerShadow(shadowStringToObject(borderBottomColor + ' 0px -' + borderBottomWidth + ' 0px 0px inset'));
+      }
+      if (borderLeftWidth !== '0px') {
+        style.addInnerShadow(shadowStringToObject(borderLeftColor + ' ' + borderLeftWidth + ' 0px 0px 0px inset'));
+      }
     }
 
     leaf.setStyle(style);

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -98,6 +98,14 @@ export default async function nodeToSketchLayers(node) {
     backgroundImage,
     borderColor,
     borderWidth,
+    borderTopWidth,
+    borderRightWidth,
+    borderBottomWidth,
+    borderLeftWidth,
+    borderTopColor,
+    borderRightColor,
+    borderBottomColor,
+    borderLeftColor,
     borderTopLeftRadius,
     borderTopRightRadius,
     borderBottomLeftRadius,
@@ -144,8 +152,6 @@ export default async function nodeToSketchLayers(node) {
       await style.addImageFill(backroundImageToUrl(backgroundImage));
     }
 
-    style.addBorder({color: borderColor, thickness: parseInt(borderWidth, 10)});
-
     if (boxShadow !== DEFAULT_VALUES.boxShadow) {
       const shadowObj = shadowStringToObject(boxShadow);
 
@@ -157,6 +163,15 @@ export default async function nodeToSketchLayers(node) {
       } else {
         style.addShadow(shadowObj);
       }
+    }
+
+    if (borderWidth.indexOf(' ') === -1) {
+      style.addBorder({color: borderColor, thickness: parseInt(borderWidth, 10)});
+    } else {
+      if (borderTopWidth !== '0px') style.addInnerShadow(shadowStringToObject(borderTopColor + ' 0px ' + borderTopWidth + ' 0px 0px inset'));
+      if (borderRightWidth !== '0px') style.addInnerShadow(shadowStringToObject(borderRightColor + ' -' + borderRightWidth + ' 0px 0px 0px inset'));
+      if (borderBottomWidth !== '0px') style.addInnerShadow(shadowStringToObject(borderBottomColor + ' 0px -' + borderBottomWidth + ' 0px 0px inset'));
+      if (borderLeftWidth !== '0px') style.addInnerShadow(shadowStringToObject(borderLeftColor + ' ' + borderLeftWidth + ' 0px 0px 0px inset'));
     }
 
     leaf.setStyle(style);

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -15,7 +15,8 @@ const DEFAULT_VALUES = {
 
 function shadowStringToObject(shadowStr) {
   let shadowObj = {};
-  const matches = shadowStr.match(/^([a-z0-9#., ()]+) ([-]?[0-9.]+)px ([-]?[0-9.]+)px ([-]?[0-9.]+)px ([-]?[0-9.]+)px ?(inset)?$/i);
+  const matches =
+    shadowStr.match(/^([a-z0-9#., ()]+) ([-]?[0-9.]+)px ([-]?[0-9.]+)px ([-]?[0-9.]+)px ([-]?[0-9.]+)px ?(inset)?$/i);
 
   if (matches && matches.length === 7) {
     shadowObj = {

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -147,10 +147,15 @@ export default async function nodeToSketchLayers(node) {
     style.addBorder({color: borderColor, thickness: parseInt(borderWidth, 10)});
 
     if (boxShadow !== DEFAULT_VALUES.boxShadow) {
+      const shadowObj = shadowStringToObject(boxShadow);
+
       if (boxShadow.indexOf('inset') !== -1) {
-        style.addInnerShadow(shadowStringToObject(boxShadow));
+        if (borderWidth.indexOf(' ') === -1) {
+          shadowObj.spread += parseInt(borderWidth, 10);
+        }
+        style.addInnerShadow(shadowObj);
       } else {
-        style.addShadow(shadowStringToObject(boxShadow));
+        style.addShadow(shadowObj);
       }
     }
 

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -14,9 +14,9 @@ const DEFAULT_VALUES = {
 
 function shadowStringToObject(shadowStr) {
   let shadowObj = {};
-  const matches = shadowStr.match(/^([a-z0-9#., ()]+) ([-]?[0-9.]+)px ([-]?[0-9.]+)px ([-]?[0-9.]+)px ([-]?[0-9.]+)px/i);
+  const matches = shadowStr.match(/^([a-z0-9#., ()]+) ([-]?[0-9.]+)px ([-]?[0-9.]+)px ([-]?[0-9.]+)px ([-]?[0-9.]+)px ?(inset)?$/i);
 
-  if (matches && matches.length === 6) {
+  if (matches && matches.length === 7) {
     shadowObj = {
       color: matches[1],
       offsetX: matches[2],

--- a/html2asketch/style.js
+++ b/html2asketch/style.js
@@ -5,6 +5,7 @@ class Style {
     this._fills = [];
     this._borders = [];
     this._shadows = [];
+    this._innerShadows = [];
   }
 
   addColorFill(color) {
@@ -45,12 +46,30 @@ class Style {
     });
   }
 
+  addInnerShadow({color = '#000', blur = 1, offsetX = 0, offsetY = 0, spread = 0}) {
+    this._innerShadows.push({
+      _class: 'innerShadow',
+      isEnabled: true,
+      blurRadius: blur,
+      color: makeColorFromCSS(color),
+      contextSettings: {
+        _class: 'graphicsContextSettings',
+        blendMode: 0,
+        opacity: 1
+      },
+      offsetX,
+      offsetY,
+      spread
+    });
+  }
+
   toJSON() {
     return {
       '_class': 'style',
       'fills': this._fills,
       'borders': this._borders,
       'shadows': this._shadows,
+      'innerShadows': this._innerShadows,
       'endDecorationType': 0,
       'miterLimit': 10,
       'startDecorationType': 0


### PR DESCRIPTION
I add inner shadow style.
And edit to support negative shadow values.

This code works well.
But, I do not think this is a cool code.
Please do a harsh review.

And this code has a problem.

If an element has a border, the `innerShadow` is covered by the `borderWidth`.
I suggest two solutions.

1. Reduce the `width` and `height` by twice the` borderWidth`, and apply the border to `outside`.
This is similar to how html works. But it is very complicated. You must also modify the `left` and` top` values.

2. Add the `Spread` value of the inner shadow by `borderWidth`.
This is simple, but, very trick. If the project starts to support one side border, there is a problem.

Neither is perfect.

What do you think?