### PR TITLE
add initial support for overflow: hidden

### DIFF
--- a/html2asketch/helpers/findParentWithStyle.js
+++ b/html2asketch/helpers/findParentWithStyle.js
@@ -1,0 +1,14 @@
+export default function findParentWithStyle(child, property, value) {
+  let parent = child.parentElement;
+
+  while (parent) {
+    if (getComputedStyle(parent)[property] === value) {
+      return parent;
+    }
+
+    parent = parent.parentElement;
+  }
+
+  // parent with style not found
+  return undefined;
+}

--- a/html2asketch/helpers/findParentWithStyle.spec.js
+++ b/html2asketch/helpers/findParentWithStyle.spec.js
@@ -1,0 +1,25 @@
+import findParentWithStyle from './findParentWithStyle';
+
+test('finds parent node with style', () => {
+  const parent = document.createElement('div');
+
+  parent.setAttribute('style', 'opacity:0.5;');
+
+  const child = document.createElement('span');
+
+  parent.appendChild(child);
+
+  expect(findParentWithStyle(child, 'opacity', '0.5')).toBeDefined();
+});
+
+test('returns undefined', () => {
+  const parent = document.createElement('div');
+
+  parent.setAttribute('style', 'color:blue;');
+
+  const child = document.createElement('span');
+
+  parent.appendChild(child);
+
+  expect(findParentWithStyle(child, 'overflow', 'hidden')).not.toBeDefined();
+});

--- a/html2asketch/rectangle.js
+++ b/html2asketch/rectangle.js
@@ -1,12 +1,18 @@
 import Base from './base';
 
 class Rectangle extends Base {
-  constructor({width, height, cornerRadius = {topLeft: 0, bottomLeft: 0, topRight: 0, bottomRight: 0}}) {
+  constructor({
+    width,
+    height,
+    cornerRadius = {topLeft: 0, bottomLeft: 0, topRight: 0, bottomRight: 0},
+    shouldBreakMaskChain
+  }) {
     super();
     this._class = 'rectangle';
     this._width = width;
     this._height = height;
     this._cornerRadius = cornerRadius;
+    this._shouldBreakMaskChain = shouldBreakMaskChain;
   }
 
   toJSON() {
@@ -73,6 +79,7 @@ class Rectangle extends Base {
     obj.fixedRadius = 0;
     obj.edited = false;
     obj.booleanOperation = -1;
+    obj.shouldBreakMaskChain = this._shouldBreakMaskChain;
 
     return obj;
   }

--- a/html2asketch/shapeGroup.js
+++ b/html2asketch/shapeGroup.js
@@ -1,13 +1,14 @@
 import Base from './base';
 
 class ShapeGroup extends Base {
-  constructor({x, y, width, height}) {
+  constructor({x, y, width, height, hasMask}) {
     super();
     this._class = 'shapeGroup';
     this._x = x;
     this._y = y;
     this._width = width;
     this._height = height;
+    this._hasMask = hasMask;
   }
 
   toJSON() {
@@ -24,7 +25,7 @@ class ShapeGroup extends Base {
 
     obj.hasClickThrough = false;
     obj.clippingMaskMode = 0;
-    obj.hasClippingMask = false;
+    obj.hasClippingMask = this._hasMask;
     obj.windingRule = 1;
 
     return obj;

--- a/html2asketch/text.js
+++ b/html2asketch/text.js
@@ -1,7 +1,7 @@
 import Base from './base';
 
 class Text extends Base {
-  constructor({x, y, width, height, text, style, multiline}) {
+  constructor({x, y, width, height, text, style, multiline, shouldBreakMaskChain}) {
     super();
     this._class = 'text';
     this._x = x;
@@ -12,6 +12,7 @@ class Text extends Base {
     this._name = text;
     this._style = style;
     this._multiline = multiline;
+    this._shouldBreakMaskChain = shouldBreakMaskChain;
   }
 
   toJSON() {
@@ -38,6 +39,7 @@ class Text extends Base {
     // 1 - width is set to Fixed
     // 0 - width is set to Auto - this helps us avoid issues with browser setting too small width causing line to break
     obj.textBehaviour = this._multiline ? 1 : 0;
+    obj.shouldBreakMaskChain = this._shouldBreakMaskChain;
     return obj;
   }
 }


### PR DESCRIPTION
This PR adds basic support for overflow: hidden, but I'm not sure it's the right approach to go with. For instance, would it be better to start grouping nodes and their children elements and applying masks within the group?

On another note, what do you think about allowing a config object to be passed to `Base`. It seems we may want to start allowing additional configuration options on top of `shouldBreakMaskChain`. And if we pass a whitelisted set of objects to `Base`'s constructor, we would have a more extensible approach moving forward.