### PR TITLE
fix(overflow): only skip node if overflow is hidden

### DIFF
--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -79,10 +79,6 @@ export default async function nodeToSketchLayers(node) {
   const layers = [];
   const {width, height, x, y} = node.getBoundingClientRect();
 
-  if (width === 0 || height === 0) {
-    return layers;
-  }
-
   const styles = getComputedStyle(node);
   const {
     backgroundColor,
@@ -114,8 +110,14 @@ export default async function nodeToSketchLayers(node) {
     display,
     boxShadow,
     visibility,
-    opacity
+    opacity,
+    overflowX,
+    overflowY
   } = styles;
+
+  if ((width === 0 || height === 0) && overflowX === 'hidden' && overflowY === 'hidden') {
+    return layers;
+  }
 
   if (display === 'none' || visibility === 'hidden' || parseFloat(opacity) === 0) {
     return layers;


### PR DESCRIPTION
content of a node can still be visible if height and width are zero, and overflow is set to `'visible'`