### PR TITLE
Skip node when style.display is set to 'none' for itself or an ancestor

### DIFF
--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -112,8 +112,15 @@ export default async function nodeToSketchLayers(node) {
     visibility,
     opacity,
     overflowX,
-    overflowY
+    overflowY,
+    position
   } = styles;
+
+  // Skip node when display is set to none for itself or an ancestor
+  // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
+  if (node.offsetParent === null && position !== 'fixed') {
+    return layers;
+  }
 
   if ((width === 0 || height === 0) && overflowX === 'hidden' && overflowY === 'hidden') {
     return layers;


### PR DESCRIPTION
This fixes an issue that https://github.com/brainly/html-sketchapp/commit/6fa6f7f5c4f769b40892b93215e4a6429dab67ca introduced with my style guide.

I narrowed it to this commit by rolling forward commit-by-commit from the last known working version.

Elements that were correctly hidden were suddenly being rendered, and it actually had a knock-on effect where the symbol itself would seemingly become invalid and get ignored by Sketch, leading to a bunch of missing symbols.

The only contentious part of this PR, from what I can tell, is that fixed elements will no longer be rendered, but this seems sensible given we're rendering to Sketch. Happy to alter this PR and check for fixed position if you disagree with this change.