### PR TITLE
Fix build error

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,3 @@
 {
-  "env": {
-    "test": {
-      "plugins": ["transform-es2015-modules-commonjs"]
-    }
-  }
+  "presets": ["airbnb"]
 }

--- a/asketch2sketch.sketchplugin/Contents/Sketch/asketch2sketch.js
+++ b/asketch2sketch.sketchplugin/Contents/Sketch/asketch2sketch.js
@@ -277,8 +277,68 @@ module.exports = {
 /* WEBPACK VAR INJECTION */(function(console) {Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports['default'] = asketch2sketch;
 
-exports['default'] = function (context) {
+var _sketchappJsonPlugin = __webpack_require__(2);
+
+var _fixFont = __webpack_require__(7);
+
+var _fixImageFill = __webpack_require__(15);
+
+var _fixImageFill2 = _interopRequireDefault(_fixImageFill);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+function removeExistingLayers(context) {
+  if (context.containsLayers()) {
+    var loop = context.children().objectEnumerator();
+    var currLayer = loop.nextObject();
+
+    while (currLayer) {
+      if (currLayer !== context) {
+        currLayer.removeFromParent();
+      }
+      currLayer = loop.nextObject();
+    }
+  }
+}
+
+function fixLayer(layer) {
+  if (layer['_class'] === 'text') {
+    (0, _fixFont.fixTextLayer)(layer);
+  } else {
+    (0, _fixImageFill2['default'])(layer);
+  }
+
+  if (layer.layers) {
+    layer.layers.forEach(fixLayer);
+  }
+}
+
+function removeSharedTextStyles(document) {
+  document.documentData().layerTextStyles().setObjects([]);
+}
+
+function addSharedTextStyle(document, style) {
+  var textStyles = document.documentData().layerTextStyles();
+
+  textStyles.addSharedStyleWithName_firstInstance(style.name, (0, _sketchappJsonPlugin.fromSJSONDictionary)(style.value));
+}
+
+function removeSharedColors(document) {
+  var assets = document.documentData().assets();
+
+  assets.removeAllColors();
+}
+
+function addSharedColor(document, colorJSON) {
+  var assets = document.documentData().assets();
+  var color = (0, _sketchappJsonPlugin.fromSJSONDictionary)(colorJSON);
+
+  assets.addColor(color);
+}
+
+function asketch2sketch(context) {
   var document = context.document;
   var page = document.currentPage();
 
@@ -290,7 +350,7 @@ exports['default'] = function (context) {
   panel.setCanChooseDirectories(false);
   panel.setCanChooseFiles(true);
   panel.setAllowsMultipleSelection(true);
-  panel.setTitle('Choose a asketch.json files');
+  panel.setTitle('Choose *.asketch.json files');
   panel.setPrompt('Choose');
   panel.setAllowedFileTypes(['json']);
 
@@ -356,65 +416,6 @@ exports['default'] = function (context) {
 
     console.log('Layers added: ' + asketchPage.layers.length);
   }
-};
-
-var _sketchappJsonPlugin = __webpack_require__(2);
-
-var _fixFont = __webpack_require__(7);
-
-var _fixImageFill = __webpack_require__(15);
-
-var _fixImageFill2 = _interopRequireDefault(_fixImageFill);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-function removeExistingLayers(context) {
-  if (context.containsLayers()) {
-    var loop = context.children().objectEnumerator();
-    var currLayer = loop.nextObject();
-
-    while (currLayer) {
-      if (currLayer !== context) {
-        currLayer.removeFromParent();
-      }
-      currLayer = loop.nextObject();
-    }
-  }
-}
-
-function fixLayer(layer) {
-  if (layer['_class'] === 'text') {
-    (0, _fixFont.fixTextLayer)(layer);
-  } else {
-    (0, _fixImageFill2['default'])(layer);
-  }
-
-  if (layer.layers) {
-    layer.layers.forEach(fixLayer);
-  }
-}
-
-function removeSharedTextStyles(document) {
-  document.documentData().layerTextStyles().setObjects([]);
-}
-
-function addSharedTextStyle(document, style) {
-  var textStyles = document.documentData().layerTextStyles();
-
-  textStyles.addSharedStyleWithName_firstInstance(style.name, (0, _sketchappJsonPlugin.fromSJSONDictionary)(style.value));
-}
-
-function removeSharedColors(document) {
-  var assets = document.documentData().assets();
-
-  assets.removeAllColors();
-}
-
-function addSharedColor(document, colorJSON) {
-  var assets = document.documentData().assets();
-  var color = (0, _sketchappJsonPlugin.fromSJSONDictionary)(colorJSON);
-
-  assets.addColor(color);
 }
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(0)))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1014,15 +1014,15 @@
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-jscript": "6.22.0",
         "babel-plugin-transform-object-rest-spread": "6.26.0",
-        "babel-preset-env": "1.6.0",
+        "babel-preset-env": "1.6.1",
         "babel-preset-react": "6.24.1",
         "object.assign": "4.0.4"
       }
     },
     "babel-preset-env": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
-      "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
@@ -1052,7 +1052,7 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.3.3",
+        "browserslist": "2.9.1",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       }
@@ -1365,13 +1365,13 @@
       }
     },
     "browserslist": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.3.tgz",
-      "integrity": "sha512-p9hz6FA2H1w1ZUAXKfK3MlIA4Z9fEd56hnZSOecBIITb5j0oZk/tZRwhdE0xG56RGx2x8cc1c5AWJKWVjMLOEQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.1.tgz",
+      "integrity": "sha512-3n3nPdbUqn3nWmsy4PeSQthz2ja1ndpoXta+dwFFNhveGjMg6FXpWYe12vsTpNoXJbzx3j7GZXdtoVIdvh3JbA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000717",
-        "electron-to-chromium": "1.3.18"
+        "caniuse-lite": "1.0.30000775",
+        "electron-to-chromium": "1.3.27"
       }
     },
     "bser": {
@@ -1434,9 +1434,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000717",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000717.tgz",
-      "integrity": "sha1-RTmxJq94fB1IUZRN4isr2HgNNhI=",
+      "version": "1.0.30000775",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000775.tgz",
+      "integrity": "sha1-dNJ/7dxH88hM+8sTDDCSo168LeI=",
       "dev": true
     },
     "caseless": {
@@ -1973,9 +1973,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.18",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
-      "integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw=",
+      "version": "1.3.27",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
+      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
       "dev": true
     },
     "elliptic": {
@@ -5938,9 +5938,9 @@
       }
     },
     "regenerate": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -5976,7 +5976,7 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.2",
+        "regenerate": "1.3.3",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
       }

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
     "sketch": ">=3.0"
   },
   "devDependencies": {
-    "jest": "^21.2.1",
+    "babel-preset-airbnb": "^2.4.0",
     "eslint": "^4.4.1",
     "frontend-tools-configs": "git+https://github.com/brainly/frontend-tools-configs.git#v16.1.0",
-    "skpm": "^0.10.2"
+    "jest": "^21.2.1",
+    "skpm": "^0.10.3"
   },
   "skpm": {
     "manifest": "asketch2sketch/manifest.json",


### PR DESCRIPTION
@arahansen this is based on your PR. Our `.babelrc` was only intended for jest tests, but it was also read by `skpm` overwriting their default babel settings and causing build errors. I ended up using the same preset they are using (airbnb) which works for both jest tests and skpm.