### PR TITLE
Add 0.1 to width for multiline text

### DIFF
--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -250,7 +250,7 @@ export default async function nodeToSketchLayers(node) {
       const text = new Text({
         x: textBCR.x,
         y: textBCR.y + fixY,
-        width: textBCR.width,
+        width: textBCR.width + 0.1,
         height: textBCR.height,
         text: textNode.nodeValue.trim(),
         style: textStyle,


### PR DESCRIPTION
Can refer PR #35 for detail.

Multiline text is set to Fixed width.
Its width is rather small. So the text is rendered incorrectly.

I tested various styles of text. font-family, width, font-size, letter-spacing ...
Styles did not affect the deficit value.
They required an additional value of 0.01 to 0.1.

Its reason is hard to find.
So provisionally, I suggest adding 0.1 to the width.


**html :**
```html
<p style="font-size: 12px; width: 200px">
  Lorem ipsum dolor sit amet, adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
</p>
```

**Browser :**
<img width="214" alt="2017-12-05 11 10 56" src="https://user-images.githubusercontent.com/16788797/33613266-88cb8316-da17-11e7-8f4c-209d8fc5af82.png">

**Sketch :**
<img width="210" alt="2017-12-05 11 11 01" src="https://user-images.githubusercontent.com/16788797/33613281-926d0804-da17-11e7-9b97-b02e4ff92f49.png">