### PR TITLE
fix #43

### DIFF
--- a/asketch2sketch.sketchplugin/Contents/Sketch/asketch2sketch.js
+++ b/asketch2sketch.sketchplugin/Contents/Sketch/asketch2sketch.js
@@ -802,7 +802,9 @@ function makeEncodedAttributedString(textNodes) {
     fullStr.appendAttributedString(newString);
   });
 
-  var msAttribStr = MSAttributedString.alloc().initWithAttributedString(fullStr);
+  var encodedAttribStr = MSAttributedString.encodeAttributedString(fullStr);
+
+  var msAttribStr = MSAttributedString.alloc().initWithEncodedAttributedString(encodedAttribStr);
 
   return encodeSketchJSON(msAttribStr);
 }

--- a/asketch2sketch/helpers/fixFont.js
+++ b/asketch2sketch/helpers/fixFont.js
@@ -107,8 +107,10 @@ function makeEncodedAttributedString(textNodes) {
     fullStr.appendAttributedString(newString);
   });
 
-  const msAttribStr = MSAttributedString.alloc().initWithAttributedString(
-    fullStr
+  const encodedAttribStr = MSAttributedString.encodeAttributedString(fullStr);
+
+  const msAttribStr = MSAttributedString.alloc().initWithEncodedAttributedString(
+    encodedAttribStr
   );
 
   return encodeSketchJSON(msAttribStr);


### PR DESCRIPTION
#43
The message is that `initWithAttributedString` is `undefined`.
So, I use `initWithEncodedAttributedString` instead.