### PR TITLE
Skip node that has 'clip : rect (0px 0px 0px 0px)'

### DIFF
--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -113,7 +113,8 @@ export default async function nodeToSketchLayers(node) {
     opacity,
     overflowX,
     overflowY,
-    position
+    position,
+    clip
   } = styles;
 
   // Skip node when display is set to none for itself or an ancestor
@@ -127,6 +128,10 @@ export default async function nodeToSketchLayers(node) {
   }
 
   if (display === 'none' || visibility === 'hidden' || parseFloat(opacity) === 0) {
+    return layers;
+  }
+
+  if (clip === 'rect(0px 0px 0px 0px)' && position === 'absolute') {
     return layers;
   }
 


### PR DESCRIPTION
Many webs use labels for screen readers.
Its style is like this.

```css
.sr-only {
  position: absolute;
  width: 1px;
  height: 1px;
  padding: 0;
  margin: -1px;
  overflow: hidden;
  clip: rect(0,0,0,0);
  border: 0;
}
```

This is not visible.
We need skip this.