### PR TITLE
Support svg

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,6 +42,7 @@
     "NSString": false,
     "NSUTF8StringEncoding": false,
     "NSAlert": false,
-    "NSMutableAttributedString": false
+    "NSMutableAttributedString": false,
+    "MSSVGImporter": false
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 .editorconfig
 node_modules/
+test/

--- a/asketch2sketch.sketchplugin/Contents/Sketch/asketch2sketch.js
+++ b/asketch2sketch.sketchplugin/Contents/Sketch/asketch2sketch.js
@@ -374,7 +374,7 @@ var _fixImageFill = __webpack_require__(16);
 
 var _fixImageFill2 = _interopRequireDefault(_fixImageFill);
 
-var _makeSVGLayer = __webpack_require__(16);
+var _makeSVGLayer = __webpack_require__(17);
 
 var _makeSVGLayer2 = _interopRequireDefault(_makeSVGLayer);
 
@@ -1994,7 +1994,7 @@ function fixImageFill(layer) {
 }
 
 /***/ }),
-/* 16 */
+/* 17 */
 /***/ (function(module, exports) {
 
 Object.defineProperty(exports, "__esModule", {
@@ -2003,9 +2003,7 @@ Object.defineProperty(exports, "__esModule", {
 exports["default"] = makeSVGLayer;
 function makeSVGLayer(layer) {
   var svgString = NSString.stringWithString(layer.rawSVGString);
-  // eslint-disable-next-line no-undef
   var svgData = svgString.dataUsingEncoding(NSUTF8StringEncoding);
-  // eslint-disable-next-line no-undef
   var svgImporter = MSSVGImporter.svgImporter();
 
   svgImporter.prepareToImportFromData(svgData);

--- a/asketch2sketch.sketchplugin/Contents/Sketch/asketch2sketch.js
+++ b/asketch2sketch.sketchplugin/Contents/Sketch/asketch2sketch.js
@@ -295,6 +295,10 @@ var _fixImageFill = __webpack_require__(15);
 
 var _fixImageFill2 = _interopRequireDefault(_fixImageFill);
 
+var _makeSVGLayer = __webpack_require__(16);
+
+var _makeSVGLayer2 = _interopRequireDefault(_makeSVGLayer);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
 function removeExistingLayers(context) {
@@ -320,6 +324,15 @@ function fixLayer(layer) {
 
   if (layer.layers) {
     layer.layers.forEach(fixLayer);
+  }
+}
+
+function getNativeLayer(layer) {
+  if (layer['_class'] === 'svg') {
+    return (0, _makeSVGLayer2['default'])(layer);
+  } else {
+    fixLayer(layer);
+    return (0, _sketchappJsonPlugin.fromSJSONDictionary)(layer);
   }
 }
 
@@ -418,9 +431,10 @@ function asketch2sketch(context) {
     page.name = asketchPage.name;
 
     asketchPage.layers.forEach(function (layer) {
-      fixLayer(layer);
+      var nativeLayer = getNativeLayer(layer);
+
       try {
-        page.addLayer((0, _sketchappJsonPlugin.fromSJSONDictionary)(layer));
+        page.addLayer(nativeLayer);
       } catch (e) {
         console.log('Layer couldn\'t be created');
         console.log(e);
@@ -1792,6 +1806,32 @@ function fixImageFill(layer) {
 
     delete fill.image.url;
   });
+}
+
+/***/ }),
+/* 16 */
+/***/ (function(module, exports) {
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = makeSVGLayer;
+function makeSVGLayer(layer) {
+  var svgString = NSString.stringWithString(layer.rawSVGString);
+  // eslint-disable-next-line no-undef
+  var svgData = svgString.dataUsingEncoding(NSUTF8StringEncoding);
+  // eslint-disable-next-line no-undef
+  var svgImporter = MSSVGImporter.svgImporter();
+
+  svgImporter.prepareToImportFromData(svgData);
+  var svgLayer = svgImporter.importAsLayer();
+
+  svgLayer.frame().setX(layer.x);
+  svgLayer.frame().setY(layer.y);
+  svgLayer.frame().setHeight(layer.height);
+  svgLayer.frame().setWidth(layer.width);
+
+  return svgLayer;
 }
 
 /***/ })

--- a/asketch2sketch.sketchplugin/Contents/Sketch/asketch2sketch.js
+++ b/asketch2sketch.sketchplugin/Contents/Sketch/asketch2sketch.js
@@ -2009,10 +2009,37 @@ function makeSVGLayer(layer) {
   svgImporter.prepareToImportFromData(svgData);
   var svgLayer = svgImporter.importAsLayer();
 
-  svgLayer.frame().setX(layer.x);
-  svgLayer.frame().setY(layer.y);
-  svgLayer.frame().setHeight(layer.height);
-  svgLayer.frame().setWidth(layer.width);
+  // imported svg may have different size, and proportions, than expected by the `layer`
+  // we have to do resizing and centering ourselves to avoid stretching of the image
+  var expectedWidth = layer.width;
+  var expectedHeight = layer.height;
+  var actualWidth = svgLayer.frame().width();
+  var actualHeight = svgLayer.frame().height();
+
+  if (actualWidth === 0 || actualHeight === 0) {
+    svgLayer.frame().setX(layer.x);
+    svgLayer.frame().setY(layer.y);
+    svgLayer.frame().setWidth(layer.width);
+    svgLayer.frame().setHeight(layer.height);
+
+    return svgLayer;
+  }
+
+  var resultWidth = expectedWidth;
+  var resultHeight = expectedWidth / actualWidth * actualHeight;
+
+  if (actualHeight > actualWidth) {
+    resultHeight = expectedHeight;
+    resultWidth = expectedHeight / actualHeight * actualWidth;
+  }
+
+  var fixX = (expectedWidth - resultWidth) / 2;
+  var fixY = (expectedHeight - resultHeight) / 2;
+
+  svgLayer.frame().setX(layer.x + fixX);
+  svgLayer.frame().setY(layer.y + fixY);
+  svgLayer.frame().setWidth(resultWidth);
+  svgLayer.frame().setHeight(resultHeight);
 
   return svgLayer;
 }

--- a/asketch2sketch.sketchplugin/Contents/Sketch/asketch2sketch.js
+++ b/asketch2sketch.sketchplugin/Contents/Sketch/asketch2sketch.js
@@ -2009,37 +2009,10 @@ function makeSVGLayer(layer) {
   svgImporter.prepareToImportFromData(svgData);
   var svgLayer = svgImporter.importAsLayer();
 
-  // imported svg may have different size, and proportions, than expected by the `layer`
-  // we have to do resizing and centering ourselves to avoid stretching of the image
-  var expectedWidth = layer.width;
-  var expectedHeight = layer.height;
-  var actualWidth = svgLayer.frame().width();
-  var actualHeight = svgLayer.frame().height();
-
-  if (actualWidth === 0 || actualHeight === 0) {
-    svgLayer.frame().setX(layer.x);
-    svgLayer.frame().setY(layer.y);
-    svgLayer.frame().setWidth(layer.width);
-    svgLayer.frame().setHeight(layer.height);
-
-    return svgLayer;
-  }
-
-  var resultWidth = expectedWidth;
-  var resultHeight = expectedWidth / actualWidth * actualHeight;
-
-  if (actualHeight > actualWidth) {
-    resultHeight = expectedHeight;
-    resultWidth = expectedHeight / actualHeight * actualWidth;
-  }
-
-  var fixX = (expectedWidth - resultWidth) / 2;
-  var fixY = (expectedHeight - resultHeight) / 2;
-
-  svgLayer.frame().setX(layer.x + fixX);
-  svgLayer.frame().setY(layer.y + fixY);
-  svgLayer.frame().setWidth(resultWidth);
-  svgLayer.frame().setHeight(resultHeight);
+  svgLayer.frame().setX(layer.x);
+  svgLayer.frame().setY(layer.y);
+  svgLayer.frame().setWidth(layer.width);
+  svgLayer.frame().setHeight(layer.height);
 
   return svgLayer;
 }

--- a/asketch2sketch.sketchplugin/Contents/Sketch/manifest.json
+++ b/asketch2sketch.sketchplugin/Contents/Sketch/manifest.json
@@ -17,9 +17,10 @@
   },
   "version": "1.0.0",
   "description": "HTML to Sketch",
+  "homepage": "https://github.com/brainly/html-sketchapp#readme",
   "name": "asketch2sketch",
   "disableCocoaScriptPreprocessor": true,
-  "appcast": "https://raw.githubusercontent.com//master/.appcast.xml",
+  "appcast": "https://raw.githubusercontent.com/brainly/html-sketchapp/master/.appcast.xml",
   "author": "Brainly - Konrad Dzwinel",
   "email": "konrad.dzwinel@brainly.com"
 }

--- a/asketch2sketch/asketch2sketch.js
+++ b/asketch2sketch/asketch2sketch.js
@@ -1,6 +1,7 @@
 import {fromSJSONDictionary} from 'sketchapp-json-plugin';
 import {fixTextLayer, fixSharedTextStyle} from './helpers/fixFont';
 import fixImageFill from './helpers/fixImageFill';
+import makeSVGLayer from './helpers/makeSVGLayer';
 
 function removeExistingLayers(context) {
   if (context.containsLayers()) {
@@ -25,6 +26,15 @@ function fixLayer(layer) {
 
   if (layer.layers) {
     layer.layers.forEach(fixLayer);
+  }
+}
+
+function getNativeLayer(layer) {
+  if (layer['_class'] === 'svg') {
+    return makeSVGLayer(layer);
+  } else {
+    fixLayer(layer);
+    return fromSJSONDictionary(layer);
   }
 }
 
@@ -121,9 +131,10 @@ export default function asketch2sketch(context) {
     page.name = asketchPage.name;
 
     asketchPage.layers.forEach(layer => {
-      fixLayer(layer);
+      const nativeLayer = getNativeLayer(layer);
+
       try {
-        page.addLayer(fromSJSONDictionary(layer));
+        page.addLayer(nativeLayer);
       } catch (e) {
         console.log('Layer couldn\'t be created');
         console.log(e);

--- a/asketch2sketch/helpers/makeSVGLayer.js
+++ b/asketch2sketch/helpers/makeSVGLayer.js
@@ -1,8 +1,6 @@
 export default function makeSVGLayer(layer) {
   const svgString = NSString.stringWithString(layer.rawSVGString);
-  // eslint-disable-next-line no-undef
   const svgData = svgString.dataUsingEncoding(NSUTF8StringEncoding);
-  // eslint-disable-next-line no-undef
   const svgImporter = MSSVGImporter.svgImporter();
 
   svgImporter.prepareToImportFromData(svgData);

--- a/asketch2sketch/helpers/makeSVGLayer.js
+++ b/asketch2sketch/helpers/makeSVGLayer.js
@@ -1,0 +1,17 @@
+export default function makeSVGLayer(layer) {
+  const svgString = NSString.stringWithString(layer.rawSVGString);
+  // eslint-disable-next-line no-undef
+  const svgData = svgString.dataUsingEncoding(NSUTF8StringEncoding);
+  // eslint-disable-next-line no-undef
+  const svgImporter = MSSVGImporter.svgImporter();
+
+  svgImporter.prepareToImportFromData(svgData);
+  const svgLayer = svgImporter.importAsLayer();
+
+  svgLayer.frame().setX(layer.x);
+  svgLayer.frame().setY(layer.y);
+  svgLayer.frame().setHeight(layer.height);
+  svgLayer.frame().setWidth(layer.width);
+
+  return svgLayer;
+}

--- a/asketch2sketch/helpers/makeSVGLayer.js
+++ b/asketch2sketch/helpers/makeSVGLayer.js
@@ -6,10 +6,37 @@ export default function makeSVGLayer(layer) {
   svgImporter.prepareToImportFromData(svgData);
   const svgLayer = svgImporter.importAsLayer();
 
-  svgLayer.frame().setX(layer.x);
-  svgLayer.frame().setY(layer.y);
-  svgLayer.frame().setHeight(layer.height);
-  svgLayer.frame().setWidth(layer.width);
+  // imported svg may have different size, and proportions, than expected by the `layer`
+  // we have to do resizing and centering ourselves to avoid stretching of the image
+  const expectedWidth = layer.width;
+  const expectedHeight = layer.height;
+  const actualWidth = svgLayer.frame().width();
+  const actualHeight = svgLayer.frame().height();
+
+  if (actualWidth === 0 || actualHeight === 0) {
+    svgLayer.frame().setX(layer.x);
+    svgLayer.frame().setY(layer.y);
+    svgLayer.frame().setWidth(layer.width);
+    svgLayer.frame().setHeight(layer.height);
+
+    return svgLayer;
+  }
+
+  let resultWidth = expectedWidth;
+  let resultHeight = (expectedWidth / actualWidth) * actualHeight;
+
+  if (actualHeight > actualWidth) {
+    resultHeight = expectedHeight;
+    resultWidth = (expectedHeight / actualHeight) * actualWidth;
+  }
+
+  const fixX = (expectedWidth - resultWidth) / 2;
+  const fixY = (expectedHeight - resultHeight) / 2;
+
+  svgLayer.frame().setX(layer.x + fixX);
+  svgLayer.frame().setY(layer.y + fixY);
+  svgLayer.frame().setWidth(resultWidth);
+  svgLayer.frame().setHeight(resultHeight);
 
   return svgLayer;
 }

--- a/asketch2sketch/helpers/makeSVGLayer.js
+++ b/asketch2sketch/helpers/makeSVGLayer.js
@@ -6,37 +6,10 @@ export default function makeSVGLayer(layer) {
   svgImporter.prepareToImportFromData(svgData);
   const svgLayer = svgImporter.importAsLayer();
 
-  // imported svg may have different size, and proportions, than expected by the `layer`
-  // we have to do resizing and centering ourselves to avoid stretching of the image
-  const expectedWidth = layer.width;
-  const expectedHeight = layer.height;
-  const actualWidth = svgLayer.frame().width();
-  const actualHeight = svgLayer.frame().height();
-
-  if (actualWidth === 0 || actualHeight === 0) {
-    svgLayer.frame().setX(layer.x);
-    svgLayer.frame().setY(layer.y);
-    svgLayer.frame().setWidth(layer.width);
-    svgLayer.frame().setHeight(layer.height);
-
-    return svgLayer;
-  }
-
-  let resultWidth = expectedWidth;
-  let resultHeight = (expectedWidth / actualWidth) * actualHeight;
-
-  if (actualHeight > actualWidth) {
-    resultHeight = expectedHeight;
-    resultWidth = (expectedHeight / actualHeight) * actualWidth;
-  }
-
-  const fixX = (expectedWidth - resultWidth) / 2;
-  const fixY = (expectedHeight - resultHeight) / 2;
-
-  svgLayer.frame().setX(layer.x + fixX);
-  svgLayer.frame().setY(layer.y + fixY);
-  svgLayer.frame().setWidth(resultWidth);
-  svgLayer.frame().setHeight(resultHeight);
+  svgLayer.frame().setX(layer.x);
+  svgLayer.frame().setY(layer.y);
+  svgLayer.frame().setWidth(layer.width);
+  svgLayer.frame().setHeight(layer.height);
 
   return svgLayer;
 }

--- a/html2asketch/helpers/bcr.js
+++ b/html2asketch/helpers/bcr.js
@@ -1,3 +1,4 @@
+// TODO: should probably also take into account children of each node
 export function getGroupBCR(nodes) {
   const groupBCR = nodes.reduce((result, node) => {
     const {x, y, width, height} = node.getBoundingClientRect();

--- a/html2asketch/helpers/bcr.js
+++ b/html2asketch/helpers/bcr.js
@@ -1,0 +1,52 @@
+export function getGroupBCR(nodes) {
+  const groupBCR = nodes.reduce((result, node) => {
+    const {x, y, width, height} = node.getBoundingClientRect();
+
+    if (width === 0 && height === 0) {
+      return result;
+    }
+
+    if (!result) {
+      return {
+        startX: x,
+        startY: y,
+        endX: x + width,
+        endY: y + height
+      };
+    }
+
+    if (x < result.startX) {
+      result.startX = x;
+    }
+
+    if (y < result.startY) {
+      result.startY = y;
+    }
+
+    if (x + width > result.endX) {
+      result.endX = x + width;
+    }
+
+    if (y + height > result.endY) {
+      result.endY = y + height;
+    }
+
+    return result;
+  }, null);
+
+  if (groupBCR === null) {
+    return {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0
+    };
+  }
+
+  return {
+    x: groupBCR.startX,
+    y: groupBCR.startY,
+    width: groupBCR.endX - groupBCR.startX,
+    height: groupBCR.endY - groupBCR.startY
+  };
+}

--- a/html2asketch/helpers/bcr.spec.js
+++ b/html2asketch/helpers/bcr.spec.js
@@ -1,0 +1,64 @@
+import {getGroupBCR} from './bcr';
+
+test('returns default BCR if no nodes are provided', () => {
+  expect(getGroupBCR([])).toEqual({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0
+  });
+});
+
+test('for a single node returns BCR of that node', () => {
+  const node1 = {
+    getBoundingClientRect: () => ({
+      x: 10,
+      y: 10,
+      width: 100,
+      height: 100
+    })
+  };
+
+  expect(getGroupBCR([node1])).toEqual({
+    x: 10,
+    y: 10,
+    width: 100,
+    height: 100
+  });
+});
+
+test('correctly calculates BCR of multiple nodes', () => {
+  const node1 = {
+    getBoundingClientRect: () => ({
+      x: 10,
+      y: 10,
+      width: 100,
+      height: 100
+    })
+  };
+
+  const node2 = {
+    getBoundingClientRect: () => ({
+      x: 5,
+      y: 50,
+      width: 150,
+      height: 50
+    })
+  };
+
+  const node3 = {
+    getBoundingClientRect: () => ({
+      x: 5,
+      y: 500,
+      width: 150,
+      height: 500
+    })
+  };
+
+  expect(getGroupBCR([node1, node2, node3])).toEqual({
+    x: 5,
+    y: 10,
+    width: 150,
+    height: 990
+  });
+});

--- a/html2asketch/helpers/svg.js
+++ b/html2asketch/helpers/svg.js
@@ -99,6 +99,8 @@ function inlineStyles(node) {
 
 }
 
+// NOTE: this code modifies the original node by inlining all styles
+// this is not ideal and probably fixable
 export function getSVGString(svgNode) {
   const queue = Array.from(svgNode.children);
 

--- a/html2asketch/helpers/svg.js
+++ b/html2asketch/helpers/svg.js
@@ -99,6 +99,14 @@ function inlineStyles(node) {
 
 }
 
+function replaceUse(node) {
+  const href = node.href.baseVal;
+  // TODO this will only work for internal references
+  const refNode = document.querySelector(href);
+
+  return refNode ? refNode.cloneNode(true) : null;
+}
+
 // NOTE: this code modifies the original node by inlining all styles
 // this is not ideal and probably fixable
 export function getSVGString(svgNode) {
@@ -112,6 +120,16 @@ export function getSVGString(svgNode) {
       node instanceof SVGDefsElement ||
       node instanceof SVGTitleElement
     ) {
+      continue;
+    }
+
+    if (node instanceof SVGUseElement) {
+      const replacement = replaceUse(node);
+
+      if (replacement) {
+        node.parentNode.replaceChild(replacement, node);
+        queue.push(replacement);
+      }
       continue;
     }
 

--- a/html2asketch/helpers/svg.js
+++ b/html2asketch/helpers/svg.js
@@ -99,12 +99,23 @@ function inlineStyles(node) {
 
 }
 
-function replaceUse(node) {
+function getUseReplacement(node) {
   const href = node.href.baseVal;
   // TODO this will only work for internal references
   const refNode = document.querySelector(href);
+  let resultNode = null;
 
-  return refNode ? refNode.cloneNode(true) : null;
+  if (refNode) {
+    if (refNode instanceof SVGSymbolElement) {
+      resultNode = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      Array.from(refNode.attributes).forEach(attr => resultNode.setAttribute(attr.name, attr.value));
+      Array.from(refNode.cloneNode(true).children).forEach(child => resultNode.appendChild(child));
+    } else {
+      resultNode = refNode.cloneNode(true);
+    }
+  }
+
+  return resultNode;
 }
 
 // NOTE: this code modifies the original node by inlining all styles
@@ -124,7 +135,7 @@ export function getSVGString(svgNode) {
     }
 
     if (node instanceof SVGUseElement) {
-      const replacement = replaceUse(node);
+      const replacement = getUseReplacement(node);
 
       if (replacement) {
         node.parentNode.replaceChild(replacement, node);

--- a/html2asketch/helpers/svg.js
+++ b/html2asketch/helpers/svg.js
@@ -1,0 +1,122 @@
+// based on https://www.w3.org/TR/SVG2/styling.html and defaults taken from Chrome
+const SVG_STYLE_PROPERTIES = [
+  //name, default value
+  ['cx', '0px'],
+  ['cy', '0px'],
+
+  ['height', 'auto'],
+  ['width', 'auto'],
+  ['x', '0px'],
+  ['y', '0px'],
+
+  ['r', '0px'],
+
+  ['rx', 'auto'],
+  ['ry', 'auto'],
+
+  ['d', 'none'],
+
+  ['fill', 'rgb(0, 0, 0)'],
+
+  ['transform', 'none'],
+
+  ['alignment-baseline', 'auto'],
+  ['baseline-shift', '0px'],
+  ['clip', 'auto'],
+  ['clip-path', 'none'],
+  ['clip-rule', 'nonzero'],
+  ['color', 'rgb(0, 0, 0)'],
+  ['color-interpolation', 'sRGB'],
+  ['color-interpolation-filters', 'linearRGB'],
+  ['color-rendering', 'auto'],
+  ['cursor', 'auto'],
+  ['direction', 'ltr'],
+  ['display', 'inline'],
+  ['dominant-baseline', 'auto'],
+  ['fill-opacity', '1'],
+  ['fill-rule', 'nonzero'],
+  ['filter', 'none'],
+  ['flood-color', 'rgb(0, 0, 0)'],
+  ['flood-opacity', '1'],
+  ['font-family', 'Times'],
+  ['font-size', '16px'],
+  ['font-size-adjust', 'none'],
+  ['font-stretch', '100%'],
+  ['font-style', 'normal'],
+  ['font-variant', 'normal'],
+  ['font-weight', '400'],
+  ['glyph-orientation-horizontal', undefined],
+  ['glyph-orientation-vertical', undefined],
+  ['image-rendering', 'auto'],
+  ['letter-spacing', 'normal'],
+  ['lighting-color', 'rgb(255, 255, 255)'],
+  ['marker-end', 'none'],
+  ['marker-mid', 'none'],
+  ['marker-start', 'none'],
+  ['mask', 'none'],
+  ['opacity', '1'],
+  ['overflow', 'visible'],
+  ['pointer-events', 'auto'],
+  ['shape-rendering', 'auto'],
+  ['solid-color', undefined],
+  ['solid-opacity', undefined],
+  ['stop-color', 'rgb(0, 0, 0)'],
+  ['stop-opacity', '1'],
+  ['stroke', 'none'],
+  ['stroke-dasharray', 'none'],
+  ['stroke-dashoffset', '0px'],
+  ['stroke-linecap', 'butt'],
+  ['stroke-linejoin', 'miter'],
+  ['stroke-miterlimit', '4'],
+  ['stroke-opacity', '1'],
+  ['stroke-width', '1px'],
+  ['text-anchor', 'start'],
+  ['text-decoration', 'none solid rgb(0, 0, 0)'],
+  ['text-overflow', 'clip'],
+  ['text-rendering', 'auto'],
+  ['unicode-bidi', 'normal'],
+  ['vector-effect', 'none'],
+  ['visibility', 'visible'],
+  ['white-space', 'normal'],
+  ['word-spacing', '0px'],
+  ['writing-mode', 'horizontal-tb']
+];
+
+function inlineStyles(node) {
+  const styles = getComputedStyle(node);
+
+  SVG_STYLE_PROPERTIES.forEach(prop => {
+    const propName = prop[0];
+    const propDefaultValue = prop[1];
+    const propCurrentValue = styles[propName];
+    const propAttributeValue = node.getAttribute(propName);
+
+    if (propCurrentValue !== propDefaultValue &&
+    propCurrentValue !== propAttributeValue) {
+      node.style[propName] = propCurrentValue;
+    }
+  });
+
+}
+
+export function getSVGString(svgNode) {
+  const queue = Array.from(svgNode.children);
+
+  while (queue.length) {
+    const node = queue.pop();
+
+    if (
+      !(node instanceof SVGElement) ||
+      node instanceof SVGDefsElement ||
+      node instanceof SVGTitleElement
+    ) {
+      continue;
+    }
+
+    inlineStyles(node);
+
+    Array.from(node.children).forEach(child => queue.push(child));
+  }
+
+  return svgNode.outerHTML;
+}

--- a/html2asketch/helpers/svg.spec.js
+++ b/html2asketch/helpers/svg.spec.js
@@ -1,0 +1,85 @@
+import {getSVGString} from './svg';
+import {JSDOM} from 'jsdom';
+
+// unsuported by jsdom
+global.SVGDefsElement = () => {};
+global.SVGTitleElement = () => {};
+global.SVGUseElement = () => {};
+global.SVGSymbolElement = () => {};
+
+test('returns correct outer HTML of the DOM node w/o children', () => {
+  const outerHTML = 'pizza';
+  const node1 = {
+    children: [],
+    outerHTML
+  };
+
+  expect(getSVGString(node1)).toEqual(outerHTML);
+});
+
+test('returns correct outher HTML of the DOM node with children', () => {
+  const dom = new JSDOM(`
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="100" cy="100" r="100"/>
+  <rect x="10" y="10" width="30" height="30"/>
+  <g>
+    <ellipse cx="75" cy="75" rx="20" ry="5" stroke="red" fill="transparent" stroke-width="5"/>
+  </g>
+</svg>`);
+
+  const document = dom.window.document;
+  const node = document.querySelector('svg');
+
+  global.document = document;
+  global.SVGElement = dom.window.SVGElement;
+
+  //jsdom closes all tags with </bla> :(
+  expect(getSVGString(node)).toEqual(`<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="100" cy="100" r="100"></circle>
+  <rect x="10" y="10" width="30" height="30"></rect>
+  <g>
+    <ellipse cx="75" cy="75" rx="20" ry="5" stroke="red" fill="transparent" stroke-width="5"></ellipse>
+  </g>
+</svg>`);
+});
+
+test('inlines styles of the children, ignores styles with default values', () => {
+  const dom = new JSDOM(`
+<html>
+<head>
+<style>
+  #a {
+    fill: red;
+    overflow: visible; /* default value */
+    opacity: 1; /* default value */
+  }
+
+  #b {
+    fill: blue;
+    width: 40px;
+    height: 40px;
+  }
+</style>
+</head>
+<body>
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="100" cy="100" r="100" id="a"></circle>
+  <g>
+    <rect x="10" y="10" width="30" height="30" id="b"></rect>
+  </g>
+</svg>`);
+
+  const document = dom.window.document;
+  const node = document.querySelector('svg');
+
+  global.document = document;
+  global.SVGElement = dom.window.SVGElement;
+  global.getComputedStyle = dom.window.getComputedStyle;
+
+  expect(getSVGString(node)).toEqual(`<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="100" cy="100" r="100" id="a" style="fill: red;"></circle>
+  <g>
+    <rect x="10" y="10" width="30" height="30" id="b" style="height: 40px; width: 40px; fill: blue;"></rect>
+  </g>
+</svg>`);
+});

--- a/html2asketch/helpers/svg.spec.js
+++ b/html2asketch/helpers/svg.spec.js
@@ -2,10 +2,10 @@ import {getSVGString} from './svg';
 import {JSDOM} from 'jsdom';
 
 // unsuported by jsdom
-global.SVGDefsElement = () => {};
-global.SVGTitleElement = () => {};
-global.SVGUseElement = () => {};
-global.SVGSymbolElement = () => {};
+global.SVGDefsElement = () => {/*do nothing*/};
+global.SVGTitleElement = () => {/*do nothing*/};
+global.SVGUseElement = () => {/*do nothing*/};
+global.SVGSymbolElement = () => {/*do nothing*/};
 
 test('returns correct outer HTML of the DOM node w/o children', () => {
   const outerHTML = 'pizza';

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -109,6 +109,16 @@ function isVisible(node, {width, height}, {
     return false;
   }
 
+  const parent = node.parentElement;
+
+  if (
+    parent &&
+    parent.nodeName !== 'HTML' &&
+    !isVisible(parent, parent.getBoundingClientRect(), getComputedStyle(parent))
+  ) {
+    return false;
+  }
+
   return true;
 }
 

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -163,6 +163,8 @@ export default async function nodeToSketchLayers(node) {
   const isSVG = node.nodeName === 'svg';
 
   if (isSVG) {
+    // sketch ignores padding and centerging as defined by viewBox and preserveAspectRatio when
+    // importing SVG, so instead of using BCR of the SVG, we are using BCR of its children
     const childrenBCR = getGroupBCR(Array.from(node.children));
 
     layers.push(new SVG({

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -4,6 +4,7 @@ import createXPathFromElement from './helpers/createXPathFromElement';
 import Style from './style';
 import Text from './text';
 import TextStyle from './textStyle';
+import SVG from './svg';
 import {parseBackgroundImage} from './helpers/background';
 
 const DEFAULT_VALUES = {
@@ -75,6 +76,22 @@ function fixBorderRadius(borderRadius) {
   return parseInt(borderRadius, 10);
 }
 
+function isSVGDescendant(node) {
+  if (node.nodeName === 'HTML') {
+    return false;
+  }
+
+  let parent = node.parentNode;
+
+  while (parent.nodeName !== 'svg') {
+    parent = parent.parentNode;
+    if (parent === document) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export default async function nodeToSketchLayers(node) {
   const layers = [];
   const {width, height, x, y} = node.getBoundingClientRect();
@@ -116,6 +133,10 @@ export default async function nodeToSketchLayers(node) {
     position
   } = styles;
 
+  if (isSVGDescendant(node)) {
+    return layers;
+  }
+
   // Skip node when display is set to none for itself or an ancestor
   // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
   if (node.offsetParent === null && position !== 'fixed') {
@@ -132,6 +153,25 @@ export default async function nodeToSketchLayers(node) {
 
   const leaf = new ShapeGroup({x, y, width, height});
   const isImage = node.nodeName === 'IMG' && node.attributes.src;
+  const isSVG = node.nodeName.toLowerCase() === 'svg';
+
+  if (isSVG) {
+    const pathData = {};
+    let BCRNode = node;
+
+    if (node.childNodes.length === 1) {
+      BCRNode = node.childNodes[0];
+    }
+
+    const {width, height, x, y} = BCRNode.getBoundingClientRect();
+
+    pathData.width = width;
+    pathData.height = height;
+    pathData.x = x;
+    pathData.y = y;
+
+    layers.push(new SVG(Object.assign({rawSVGString: node.outerHTML}, pathData)));
+  }
 
   // if layer has no background/shadow/border/etc. skip it
   if (isImage || !hasOnlyDefaultStyles(styles)) {

--- a/html2asketch/svg.js
+++ b/html2asketch/svg.js
@@ -1,0 +1,25 @@
+import Base from './base';
+
+class SVG extends Base {
+  constructor({rawSVGString, width, height, x, y}) {
+    super();
+    this._rawSVGString = rawSVGString;
+    this._width = width;
+    this._height = height;
+    this._x = x;
+    this._y = y;
+  }
+
+  toJSON() {
+    return {
+      _class: 'svg',
+      rawSVGString: this._rawSVGString,
+      width: this._width,
+      height: this._height,
+      x: this._x,
+      y: this._y
+    };
+  }
+}
+
+export default SVG;

--- a/html2asketch/svg.js
+++ b/html2asketch/svg.js
@@ -1,7 +1,7 @@
 import Base from './base';
 
 class SVG extends Base {
-  constructor({rawSVGString, width, height, x, y}) {
+  constructor({x, y, width, height, rawSVGString}) {
     super();
     this._rawSVGString = rawSVGString;
     this._width = width;
@@ -11,6 +11,7 @@ class SVG extends Base {
   }
 
   toJSON() {
+    // NOTE: this is a non-standard extension of the .sketch format
     return {
       _class: 'svg',
       rawSVGString: this._rawSVGString,

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,20 +127,12 @@
       }
     },
     "acorn-globals": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
+        "acorn": "5.4.1"
       }
     },
     "acorn-jsx": {
@@ -371,6 +363,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
     "asynckit": {
@@ -1345,6 +1343,12 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
+    "browser-process-hrtime": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+      "dev": true
+    },
     "browser-resolve": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
@@ -2104,6 +2108,15 @@
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "4.0.2"
+      }
+    },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -2325,16 +2338,16 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "requires": {
         "esprima": "3.1.3",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -2342,6 +2355,13 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4793,6 +4813,86 @@
         "jest-mock": "21.2.0",
         "jest-util": "21.2.1",
         "jsdom": "9.12.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "dev": true
+        },
+        "acorn-globals": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+          "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+          "dev": true,
+          "requires": {
+            "acorn": "4.0.13"
+          }
+        },
+        "jsdom": {
+          "version": "9.12.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
+          "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+          "dev": true,
+          "requires": {
+            "abab": "1.0.4",
+            "acorn": "4.0.13",
+            "acorn-globals": "3.1.0",
+            "array-equal": "1.0.0",
+            "content-type-parser": "1.0.2",
+            "cssom": "0.3.2",
+            "cssstyle": "0.2.37",
+            "escodegen": "1.9.1",
+            "html-encoding-sniffer": "1.0.2",
+            "nwmatcher": "1.4.3",
+            "parse5": "1.5.1",
+            "request": "2.81.0",
+            "sax": "1.2.4",
+            "symbol-tree": "3.2.2",
+            "tough-cookie": "2.3.2",
+            "webidl-conversions": "4.0.2",
+            "whatwg-encoding": "1.0.3",
+            "whatwg-url": "4.8.0",
+            "xml-name-validator": "2.0.1"
+          }
+        },
+        "parse5": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+          "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+          "dev": true
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+          "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+          "dev": true,
+          "requires": {
+            "tr46": "0.0.3",
+            "webidl-conversions": "3.0.1"
+          },
+          "dependencies": {
+            "webidl-conversions": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+              "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+              "dev": true
+            }
+          }
+        },
+        "xml-name-validator": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+          "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+          "dev": true
+        }
       }
     },
     "jest-environment-node": {
@@ -5024,37 +5124,221 @@
       "dev": true
     },
     "jsdom": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
-      "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
+      "version": "11.6.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
+      "integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "4.0.13",
-        "acorn-globals": "3.1.0",
+        "acorn": "5.4.1",
+        "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
+        "browser-process-hrtime": "0.1.2",
         "content-type-parser": "1.0.2",
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
-        "escodegen": "1.9.0",
+        "domexception": "1.0.1",
+        "escodegen": "1.9.1",
         "html-encoding-sniffer": "1.0.2",
+        "left-pad": "1.2.0",
         "nwmatcher": "1.4.3",
-        "parse5": "1.5.1",
-        "request": "2.81.0",
+        "parse5": "4.0.0",
+        "pn": "1.1.0",
+        "request": "2.85.0",
+        "request-promise-native": "1.0.5",
         "sax": "1.2.4",
         "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.2",
+        "tough-cookie": "2.3.4",
+        "w3c-hr-time": "1.0.1",
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.3",
-        "whatwg-url": "4.8.0",
-        "xml-name-validator": "2.0.1"
+        "whatwg-url": "6.4.0",
+        "ws": "4.1.0",
+        "xml-name-validator": "3.0.0"
       },
       "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+          "dev": true
+        },
+        "boom": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+          "dev": true,
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "dev": true,
+              "requires": {
+                "hoek": "4.2.1"
+              }
+            }
+          }
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          },
+          "dependencies": {
+            "combined-stream": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+              "dev": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            }
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "dev": true,
+          "requires": {
+            "ajv": "5.2.2",
+            "har-schema": "2.0.0"
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "dev": true,
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.1",
+            "sntp": "2.1.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "dev": true,
+          "requires": {
+            "mime-db": "1.33.0"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        },
+        "request": {
+          "version": "2.85.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+          "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+          "dev": true,
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "dev": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
         }
       }
     },
@@ -5194,6 +5478,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "left-pad": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+      "dev": true
+    },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -5259,6 +5549,12 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "log-symbols": {
@@ -5889,9 +6185,9 @@
       }
     },
     "parse5": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
-      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
     "path-browserify": {
@@ -5987,6 +6283,12 @@
       "requires": {
         "find-up": "2.1.0"
       }
+    },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -6434,6 +6736,37 @@
         "tough-cookie": "2.3.2",
         "tunnel-agent": "0.6.0",
         "uuid": "3.1.0"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.4"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "dev": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        }
       }
     },
     "require-directory": {
@@ -7023,6 +7356,12 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
     "stream-browserify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
@@ -7375,10 +7714,21 @@
       }
     },
     "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
+        }
+      }
     },
     "trim-right": {
       "version": "1.0.1",
@@ -7661,6 +8011,15 @@
         "indexof": "0.0.1"
       }
     },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "0.1.2"
+      }
+    },
     "walker": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -7874,21 +8233,14 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
-      "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
       "dev": true,
       "requires": {
-        "tr46": "0.0.3",
-        "webidl-conversions": "3.0.1"
-      },
-      "dependencies": {
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-          "dev": true
-        }
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
       }
     },
     "which": {
@@ -8004,6 +8356,16 @@
         "signal-exit": "3.0.2"
       }
     },
+    "ws": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.1"
+      }
+    },
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
@@ -8011,9 +8373,9 @@
       "dev": true
     },
     "xml-name-validator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
     "xml2js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "html-sketchapp",
+  "name": "@brainly/html-sketchapp",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sketchapp-json-plugin": "^0.1.2"
   },
   "bugs": {
-    "url": "https://github.com/brainly/html-sketchapp/issues"
+    "url": "https://github.com/braigitnly/html-sketchapp/issues"
   },
   "homepage": "https://github.com/brainly/html-sketchapp#readme"
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sketchapp-json-plugin": "^0.1.2"
   },
   "bugs": {
-    "url": "https://github.com/braigitnly/html-sketchapp/issues"
+    "url": "https://github.com/brainly/html-sketchapp/issues"
   },
   "homepage": "https://github.com/brainly/html-sketchapp#readme"
 }

--- a/package.json
+++ b/package.json
@@ -17,12 +17,13 @@
     "sketch": ">=3.0"
   },
   "devDependencies": {
+    "@skpm/builder": "^0.2.0",
     "babel-preset-airbnb": "^2.4.0",
     "eslint": "^4.16.0",
     "frontend-tools-configs": "git+https://github.com/brainly/frontend-tools-configs.git#v16.1.4",
     "jest": "^21.2.1",
-    "skpm": "^1.0.12",
-    "@skpm/builder": "^0.2.0"
+    "jsdom": "^11.6.2",
+    "skpm": "^1.0.12"
   },
   "skpm": {
     "name": "asketch2sketch",


### PR DESCRIPTION
This PR refer to #4 and the forked repository of @jeroenransijn.
https://github.com/jeroenransijn/html-sketchapp/tree/add/svg-support

I am sorry to borrow a lot of code from @jeroenransijn ...

I don't know this way of PR is okay..
If this is a problem, tell me please. 😭

---

svg is added to `layers` in` json` with `"_class" : 'svg'`.
It has `svg string` and positions and sizes values.

`asketch2sketch.plugin` applies a `svg layer` differently than other layers.
It uses the `MSSVGImporter` in the sketch.

In `nodeToSketchLayers`, svg descendants are skipped.

When svg has a viewbox, the position of svg is a problem.
So, when svg has only one child, it uses the position value of the child.
If necessary,  can wrap children of svg by `<g>`.