### PR TITLE
Adds a query in image url for cross-origin fetch fail

### DIFF
--- a/html2asketch/helpers/utils.js
+++ b/html2asketch/helpers/utils.js
@@ -84,7 +84,7 @@ export const makeImageFill = async(url, patternFillType = 1) => {
     dataURL = url;
   } else {
     try {
-      dataURL = await toDataURL(url);
+      dataURL = await toDataURL(url + '?cache');
     } catch (e) {
       console.error('Issue downloading ' + url + ' (' + e.message + ')');
     }


### PR DESCRIPTION
`fetch` continues to cause cross-origin errors.

I found this yours issue in the puppeteer. @kdzwinel
https://github.com/GoogleChrome/puppeteer/issues/214
It was caused by cache.

So, I added a query to url for bypass the cache.
Now almost images are fetched well!

**before error** :
<img width="538" alt="2017-12-18 9 40 56" src="https://user-images.githubusercontent.com/16788797/34085694-b06d9f66-e3d7-11e7-966f-53f45cfae38c.png">


