### PR TITLE
exclude body when looking for display: none element

### DIFF
--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -119,7 +119,7 @@ export default async function nodeToSketchLayers(node) {
 
   // Skip node when display is set to none for itself or an ancestor
   // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
-  if (node.offsetParent === null && position !== 'fixed') {
+  if (node.offsetParent === null && position !== 'fixed' && node.nodeName !== 'BODY' || display === 'none') {
     return layers;
   }
 


### PR DESCRIPTION
There is no `offsetParent` in the `body`.
so We need to exclude body in this 'skip'.
but, body can be `display: none` itself, so need to add `~ || display === none`.