### PR TITLE
remove parseInt in fontWeight because of  'bold', 'regular' values

### DIFF
--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -228,7 +228,7 @@ export default async function nodeToSketchLayers(node) {
     fontSize: parseInt(fontSize, 10),
     lineHeight: lineHeight !== 'normal' ? parseInt(lineHeight, 10) : undefined,
     letterSpacing: letterSpacing !== 'normal' ? parseFloat(letterSpacing) : undefined,
-    fontWeight: parseInt(fontWeight, 10),
+    fontWeight,
     color,
     textTransform,
     textDecoration: textDecorationStyle,


### PR DESCRIPTION
This is the `getComputedStyle` result of` h1` which is the style of `font-weight: 700`.

**firefox**
<img width="489" alt="firefox" src="https://user-images.githubusercontent.com/16788797/35190445-655ddbf6-fea5-11e7-9c7b-8287eb366555.png">

**safari**
<img width="487" alt="safari" src="https://user-images.githubusercontent.com/16788797/35190446-6585c2ce-fea5-11e7-85b8-a7cc734d57d0.png">

**chrome**
<img width="488" alt="chrome" src="https://user-images.githubusercontent.com/16788797/35190447-65ae4cee-fea5-11e7-8d12-03074ad25222.png">

**ie11**
<img width="478" alt="win7 ie11" src="https://user-images.githubusercontent.com/16788797/35190449-66003112-fea5-11e7-933c-26cfed599759.png">

**electron**
<img width="494" alt="electron" src="https://user-images.githubusercontent.com/16788797/35190448-65d6d646-fea5-11e7-97dc-933cebbed4d4.png">


safari and electron return `bold`. and if styled `400`, They return `normal`.
We need to remove the `parseInt` For support the more browsers.
It does not affect existing numeric values.