### PR TITLE
Convert percentage border radius to px

### DIFF
--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -62,16 +62,16 @@ function calculateBCRFromRanges(ranges) {
   return {x, y, width, height};
 }
 
-function fixBorderRadius(borderRadius) {
+function fixBorderRadius(borderRadius, width, height) {
   const matches = borderRadius.match(/^([0-9.]+)(.+)$/);
 
+  // Sketch uses 'px' units for border radius, so we need to convert % to px
   if (matches && matches[2] === '%') {
-    const value = parseInt(matches[1], 10);
+    const baseVal = Math.max(width, height);
+    const percentageApplied = baseVal * (parseInt(matches[1], 10) / 100);
 
-    // not sure about this, but border-radius: 50% should be fully rounded
-    return value >= 50 ? 100 : value;
+    return Math.round(percentageApplied);
   }
-
   return parseInt(borderRadius, 10);
 }
 
@@ -209,10 +209,10 @@ export default async function nodeToSketchLayers(node) {
 
     //TODO borderRadius can be expressed in different formats and use various units - for simplicity we assume "X%"
     const cornerRadius = {
-      topLeft: fixBorderRadius(borderTopLeftRadius),
-      topRight: fixBorderRadius(borderTopRightRadius),
-      bottomLeft: fixBorderRadius(borderBottomLeftRadius),
-      bottomRight: fixBorderRadius(borderBottomRightRadius)
+      topLeft: fixBorderRadius(borderTopLeftRadius, width, height),
+      topRight: fixBorderRadius(borderTopRightRadius, width, height),
+      bottomLeft: fixBorderRadius(borderBottomLeftRadius, width, height),
+      bottomRight: fixBorderRadius(borderBottomRightRadius, width, height)
     };
 
     const rectangle = new Rectange({width, height, cornerRadius});


### PR DESCRIPTION
**Problem:**
Previously, the logic in `nodeToSketchLayers` kept percent values the same (eg. "25%" -> 25)
This causes a bug in sketch, as sketch uses px for all of it's border radius values.

## Example:
**On browser:** 
![image](https://user-images.githubusercontent.com/15869505/35721840-ba39c86c-083f-11e8-860d-c31ced8992a2.png)

`Width: 16`
`Height: 16`
`Border-radius: 25%`

**In sketch before this PR:**
![image](https://user-images.githubusercontent.com/15869505/35721791-6fca1926-083f-11e8-9210-da9de66190c2.png)
![image](https://user-images.githubusercontent.com/15869505/35721794-78152bca-083f-11e8-8201-f74aa96e7e35.png)

**In sketch after this PR:**
![image](https://user-images.githubusercontent.com/15869505/35721805-8af3e790-083f-11e8-96c7-dd18361549a4.png)
![image](https://user-images.githubusercontent.com/15869505/35721871-d23a7b8c-083f-11e8-9b50-332224585c7c.png)


Percentage to px conversion is done by finding the maximum of the height or width and multiplying it by the border radius percentage