### PR TITLE
Fix line-through text decoration

### DIFF
--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -104,7 +104,7 @@ export default async function nodeToSketchLayers(node) {
     letterSpacing,
     color,
     textTransform,
-    textDecorationStyle,
+    textDecoration,
     textAlign,
     justifyContent,
     display,
@@ -231,7 +231,7 @@ export default async function nodeToSketchLayers(node) {
     fontWeight: parseInt(fontWeight, 10),
     color,
     textTransform,
-    textDecoration: textDecorationStyle,
+    textDecoration,
     textAlign: display === 'flex' || display === 'inline-flex' ? justifyContent : textAlign
   });
 

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -104,7 +104,7 @@ export default async function nodeToSketchLayers(node) {
     letterSpacing,
     color,
     textTransform,
-    textDecoration,
+    textDecorationLine,
     textAlign,
     justifyContent,
     display,
@@ -231,7 +231,7 @@ export default async function nodeToSketchLayers(node) {
     fontWeight: parseInt(fontWeight, 10),
     color,
     textTransform,
-    textDecoration,
+    textDecoration: textDecorationLine,
     textAlign: display === 'flex' || display === 'inline-flex' ? justifyContent : textAlign
   });
 


### PR DESCRIPTION
Hey guys,

First of, super cool project!

I had a problem with line-though:ed texts, it didn't render in Sketch. I tracked down the problem and realized that
``` js
const styles = getComputedStyle(lineThoughedElement)
```
puts the `line-through` attribute in `styles.textDecorationLine` instead of `styles.textDecorationStyle`.


``` js
console.log(styles.textDecorationLine)
// 'line-through' or 'underline'

console.log(styles.textDecoration)
// 'line-through solid rgb(0, 0, 0)' or similar

console.log(styles.textDecorationStyle)
// 'solid' or 'dashed' or similar
```

I might have broken something else by doing that though, so if you have any idea why the `textDecorationStyle` used to be used instead of `textDecorationLine`, let me know.