### PR TITLE
support for generating symbolInstance nodes in asketch

### DIFF
--- a/html2asketch/symbolInstance.js
+++ b/html2asketch/symbolInstance.js
@@ -1,0 +1,39 @@
+import Base from './base';
+
+class SymbolInstance extends Base {
+  constructor({x, y, width, height, symbolID}) {
+    super();
+    this._class = 'symbolInstance';
+    this._x = x;
+    this._y = y;
+    this._width = width;
+    this._height = height;
+    this._symbolID = symbolID;
+  }
+
+  toJSON() {
+    const obj = super.toJSON();
+
+    obj.frame = {
+      '_class': 'rect',
+      'constrainProportions': false,
+      'width': this._width,
+      'height': this._height,
+      'x': this._x,
+      'y': this._y
+    };
+
+    obj.style = {
+      '_class': 'style',
+      'endDecorationType': 0,
+      'miterLimit': 10,
+      'startDecorationType': 0
+    };
+
+    obj.symbolID = this._symbolID;
+
+    return obj;
+  }
+}
+
+export default SymbolInstance;

--- a/html2asketch/symbolInstance.spec.js
+++ b/html2asketch/symbolInstance.spec.js
@@ -1,0 +1,19 @@
+import SymbolInstance from './symbolInstance';
+
+test('sets symbolID', () => {
+  const symbolID = 'pizza';
+  const symbolInstance = new SymbolInstance({x: 0, y: 0, width: 100, height: 100, symbolID});
+
+  expect(symbolInstance.toJSON().symbolID).toEqual(symbolID);
+});
+
+test('sets frame dimensions', () => {
+  const symbolInstance = new SymbolInstance({x: 0, y: 50, width: 100, height: 150, symbolID: 'pizza'});
+
+  const frame = symbolInstance.toJSON().frame;
+
+  expect(frame.x).toBe(0);
+  expect(frame.y).toBe(50);
+  expect(frame.width).toBe(100);
+  expect(frame.height).toBe(150);
+});

--- a/html2asketch/symbolMaster.js
+++ b/html2asketch/symbolMaster.js
@@ -1,5 +1,6 @@
 import {generateID} from './helpers/utils';
 import Base from './base';
+import SymbolInstance from './symbolInstance';
 
 class SymbolMaster extends Base {
   constructor({x, y}) {
@@ -7,6 +8,11 @@ class SymbolMaster extends Base {
     this._class = 'symbolMaster';
     this._x = x;
     this._y = y;
+    this._symbolID = generateID();
+  }
+
+  getSymbolInstance({x, y, width, height}) {
+    return new SymbolInstance({x, y, width, height, symbolID: this._symbolID});
   }
 
   addLayer(layer) {
@@ -77,7 +83,7 @@ class SymbolMaster extends Base {
     obj.includeBackgroundColorInExport = true;
     obj.resizesContent = false;
     obj.includeBackgroundColorInInstance = false;
-    obj.symbolID = generateID();
+    obj.symbolID = this._symbolID;
     obj.changeIdentifier = 0;
 
     return obj;

--- a/html2asketch/symbolMaster.spec.js
+++ b/html2asketch/symbolMaster.spec.js
@@ -1,0 +1,15 @@
+import SymbolMaster from './symbolMaster';
+
+test('toJSON() generates deterministic symbolIDs', () => {
+  const symbolMaster = new SymbolMaster({x: 200, y: 300});
+  const symbolID = symbolMaster.toJSON().symbolID;
+
+  expect(symbolMaster.toJSON().symbolID).toEqual(symbolID);
+});
+
+test('symbol instances have the same symbolID', () => {
+  const symbolMaster = new SymbolMaster({x: 200, y: 300});
+  const symbolInstance = symbolMaster.getSymbolInstance({x: 0, y: 0, width: 100, height: 100});
+
+  expect(symbolMaster.toJSON().symbolID).toEqual(symbolInstance.toJSON().symbolID);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "html-sketchapp",
+  "name": "@brainly/html-sketchapp",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
Hiya!

As part of implementing support for nested Sketch symbols in seek-oss/html-sketchapp-cli#22, I'd like to be able to generate `symbolInstance` nodes in asketch. 

These nodes need to have a `symbolID` key that references the `symbolMaster` node with the same ID, so I've also updated the `SymbolMaster` class to generate this ID earlier, allowing it to be consistently referenced.

(I was unsure if this class should live in this repo or in html-sketchapp-cli itself, as it's not actually imported anywhere in this project. But this is already the case with symbolMaster.js, so I guess it's fine?)