### PR TITLE
Fix option to set constraint for texts

### DIFF
--- a/html2asketch/model/text.js
+++ b/html2asketch/model/text.js
@@ -1,5 +1,5 @@
 import Base from './base';
-import {RESIZING_CONSTRAINTS, calculateResizingConstraintValue} from '../helpers/utils';
+import {RESIZING_CONSTRAINTS} from '../helpers/utils';
 
 class Text extends Base {
   constructor({x, y, width, height, text, style, multiline}) {
@@ -13,6 +13,7 @@ class Text extends Base {
     this._name = text;
     this._style = style;
     this._multiline = multiline;
+    this.setResizingConstraint(RESIZING_CONSTRAINTS.HEIGHT);
   }
 
   toJSON() {
@@ -30,7 +31,6 @@ class Text extends Base {
     obj.text = this._text;
     obj.style = this._style.toJSON();
 
-    obj.resizingConstraint = calculateResizingConstraintValue(RESIZING_CONSTRAINTS.HEIGHT);
     obj.automaticallyDrawOnUnderlyingPath = false;
     obj.dontSynchroniseWithSymbol = false;
     obj.glyphBounds = '';


### PR DESCRIPTION
This solution would allow using `setResizingConstraint` also on text.

Fixes #100

@kdzwinel could you please have a look if this make sense?