### PR TITLE
shadowObj.spread miscalculation

### DIFF
--- a/e2e/expected-layers.asketch.json
+++ b/e2e/expected-layers.asketch.json
@@ -5591,7 +5591,7 @@
           {
             "_class": "shadow",
             "isEnabled": true,
-            "blurRadius": "5",
+            "blurRadius": 5,
             "color": {
               "_class": "color",
               "red": 0,
@@ -5604,9 +5604,9 @@
               "blendMode": 0,
               "opacity": 1
             },
-            "offsetX": "0",
-            "offsetY": "0",
-            "spread": "2"
+            "offsetX": 0,
+            "offsetY": 0,
+            "spread": 2
           }
         ],
         "innerShadows": [],

--- a/e2e/expected-page.asketch.json
+++ b/e2e/expected-page.asketch.json
@@ -287,7 +287,7 @@
                       {
                         "_class": "shadow",
                         "isEnabled": true,
-                        "blurRadius": "5",
+                        "blurRadius": 5,
                         "color": {
                           "_class": "color",
                           "red": 0,
@@ -300,9 +300,9 @@
                           "blendMode": 0,
                           "opacity": 1
                         },
-                        "offsetX": "0",
-                        "offsetY": "0",
-                        "spread": "2"
+                        "offsetX": 0,
+                        "offsetY": 0,
+                        "spread": 2
                       }
                     ],
                     "innerShadows": [],

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -26,10 +26,10 @@ function shadowStringToObject(shadowStr) {
   if (matches && matches.length === 7) {
     shadowObj = {
       color: matches[1],
-      offsetX: matches[2],
-      offsetY: matches[3],
-      blur: matches[4],
-      spread: matches[5]
+      offsetX: parseInt(matches[2], 10),
+      offsetY: parseInt(matches[3], 10),
+      blur: parseInt(matches[4], 10),
+      spread: parseInt(matches[5] 10)
     };
   }
 

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -29,7 +29,7 @@ function shadowStringToObject(shadowStr) {
       offsetX: parseInt(matches[2], 10),
       offsetY: parseInt(matches[3], 10),
       blur: parseInt(matches[4], 10),
-      spread: parseInt(matches[5] 10)
+      spread: parseInt(matches[5], 10)
     };
   }
 


### PR DESCRIPTION
I fixed the failing e2e test for you @yakunins. Thanks again for contributing! This change will land in version 3.2.0 of html-sketchapp. BTW even though I "hijacked" your PR, you'll of course appear among contributors: https://github.com/brainly/html-sketchapp/graphs/contributors 😉 

Fixes #101