### PR TITLE
support fontWeight 'bold'  for safari and electron

### DIFF
--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -64,6 +64,14 @@ function isSVGDescendant(node) {
   return (node instanceof SVGElement) && node.matches('svg *');
 }
 
+function parseFontWeight(fontWeight) {
+  // Support 'bold' and 'normal' for Electron compatibility.
+  if (fontWeight === 'bold' || fontWeight === 'normal') {
+    return fontWeight;
+  }
+  return parseInt(fontWeight, 10);
+}
+
 export default function nodeToSketchLayers(node, options) {
   const layers = [];
   const bcr = node.getBoundingClientRect();
@@ -275,7 +283,7 @@ export default function nodeToSketchLayers(node, options) {
     fontSize: parseInt(fontSize, 10),
     lineHeight: lineHeight !== 'normal' ? parseInt(lineHeight, 10) : undefined,
     letterSpacing: letterSpacing !== 'normal' ? parseFloat(letterSpacing) : undefined,
-    fontWeight: fontWeight === 'bold' ? 700 : parseInt(fontWeight, 10),
+    fontWeight: parseFontWeight(fontWeight),
     color,
     textTransform,
     textDecoration: textDecorationLine,

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -275,7 +275,7 @@ export default function nodeToSketchLayers(node, options) {
     fontSize: parseInt(fontSize, 10),
     lineHeight: lineHeight !== 'normal' ? parseInt(lineHeight, 10) : undefined,
     letterSpacing: letterSpacing !== 'normal' ? parseFloat(letterSpacing) : undefined,
-    fontWeight: parseInt(fontWeight, 10),
+    fontWeight: fontWeight === 'bold' ? 700 : parseInt(fontWeight, 10),
     color,
     textTransform,
     textDecoration: textDecorationLine,

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -64,10 +64,16 @@ function isSVGDescendant(node) {
   return (node instanceof SVGElement) && node.matches('svg *');
 }
 
+/**
+ * @param {string} fontWeight font weight as provided by the browser
+ * @return {number} normalized font weight
+ */
 function parseFontWeight(fontWeight) {
   // Support 'bold' and 'normal' for Electron compatibility.
-  if (fontWeight === 'bold' || fontWeight === 'normal') {
-    return fontWeight;
+  if (fontWeight === 'bold') {
+    return 700;
+  } else if (fontWeight === 'normal') {
+    return 400;
   }
   return parseInt(fontWeight, 10);
 }


### PR DESCRIPTION
This PR is a fix for issue #53 .

I suggest a new proposal that does not remove parseInt.
It only returns `700` if `fontWeight` is *bold*.

The problem in this issue are 'bold' and 'normal'.
'normal' is changed `NaN` through parseInt, 
It does not generate a fontWeight value. 
If fontWeight is not specified, the sketch uses 'normal' fontWeight.

I keep making projects that use electron.
https://github.com/KimDal-hyeong/html-to-sketch-electron

I hope this PR merge...😭