### PR TITLE
Remove multiple groups for SVGs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,6 +47,7 @@
     "COSAlertWindow": false,
     "NSMakeRect": false,
     "NSBundle": false,
-    "MSSharedStyle": false
+    "MSSharedStyle": false,
+    "MSLayerGroup": false
   }
 }

--- a/asketch2sketch/helpers/fixSVG.js
+++ b/asketch2sketch/helpers/fixSVG.js
@@ -7,7 +7,11 @@ function makeNativeSVGLayer(layer) {
   const svgImporter = MSSVGImporter.svgImporter();
 
   svgImporter.prepareToImportFromData(svgData);
-  const svgLayer = svgImporter.importAsLayer();
+  let svgLayer = svgImporter.importAsLayer();
+
+  while (svgLayer && svgLayer.layers().length === 1 && svgLayer.class() instanceof MSLayerGroup) {
+    svgLayer = svgLayer.layers()[0];
+  }
 
   svgLayer.resizingConstraint = layer.resizingConstraint;
 

--- a/asketch2sketch/helpers/fixSVG.js
+++ b/asketch2sketch/helpers/fixSVG.js
@@ -14,6 +14,7 @@ function makeNativeSVGLayer(layer) {
   }
 
   svgLayer.resizingConstraint = layer.resizingConstraint;
+  svgLayer.hasClippingMask = layer.hasClippingMask;
 
   const currentSize = svgLayer.rect().size;
   const scale = Math.min(layer.width / currentSize.width, layer.height / currentSize.height);

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -6,6 +6,7 @@
 
 ## My change breaks tests
 
+First make sure that you run `npm run build`.
 If you made a legit change that breaks e2e tests, please run `npm run e2e-fix` which will override files from `/expected` folder with new values.
 
 If your change unexpectedly breaks tests, see "I want to debug tests" section below.

--- a/e2e/expected/nodeToSketchLayers/svg.html.asketch.json
+++ b/e2e/expected/nodeToSketchLayers/svg.html.asketch.json
@@ -194,7 +194,8 @@
       "height": 133.16668701171875,
       "x": 43.583335876464844,
       "y": 884.6666870117188,
-      "resizingConstraint": 63
+      "resizingConstraint": 63,
+      "hasClippingMask": false
     },
     {
       "_class": "text",
@@ -249,7 +250,8 @@
       "height": 133.16668701171875,
       "x": 41.583335876464844,
       "y": 619.2291870117188,
-      "resizingConstraint": 63
+      "resizingConstraint": 63,
+      "hasClippingMask": false
     },
     {
       "_class": "text",
@@ -304,7 +306,8 @@
       "height": 133.16668701171875,
       "x": 41.583335876464844,
       "y": 355.7916564941406,
-      "resizingConstraint": 63
+      "resizingConstraint": 63,
+      "hasClippingMask": false
     },
     {
       "_class": "text",
@@ -359,7 +362,8 @@
       "height": 133.16667938232422,
       "x": 41.583335876464844,
       "y": 92.35416412353516,
-      "resizingConstraint": 63
+      "resizingConstraint": 63,
+      "hasClippingMask": false
     },
     {
       "_class": "text",

--- a/e2e/expected/nodeTreeToSketchPage/svg.html.asketch.json
+++ b/e2e/expected/nodeTreeToSketchPage/svg.html.asketch.json
@@ -190,7 +190,8 @@
                   "height": 133.16667938232422,
                   "x": 33.583335876464844,
                   "y": 32.916664123535156,
-                  "resizingConstraint": 63
+                  "resizingConstraint": 63,
+                  "hasClippingMask": false
                 }
               ],
               "clippingMaskMode": 0,
@@ -347,7 +348,8 @@
                   "height": 133.16668701171875,
                   "x": 33.583335876464844,
                   "y": 32.916656494140625,
-                  "resizingConstraint": 63
+                  "resizingConstraint": 63,
+                  "hasClippingMask": false
                 }
               ],
               "clippingMaskMode": 0,
@@ -504,7 +506,8 @@
                   "height": 133.16668701171875,
                   "x": 33.583335876464844,
                   "y": 32.91668701171875,
-                  "resizingConstraint": 63
+                  "resizingConstraint": 63,
+                  "hasClippingMask": false
                 }
               ],
               "clippingMaskMode": 0,
@@ -828,7 +831,8 @@
                   "height": 133.16668701171875,
                   "x": 35.583335876464844,
                   "y": 34.91668701171875,
-                  "resizingConstraint": 63
+                  "resizingConstraint": 63,
+                  "hasClippingMask": false
                 }
               ],
               "clippingMaskMode": 0,

--- a/html2asketch/model/svg.js
+++ b/html2asketch/model/svg.js
@@ -19,7 +19,8 @@ class SVG extends Base {
       height: this._height,
       x: this._x,
       y: this._y,
-      resizingConstraint: this._resizingConstraint
+      resizingConstraint: this._resizingConstraint,
+      hasClippingMask: this._hasClippingMask
     };
   }
 }

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -261,7 +261,6 @@ export default function nodeToSketchLayers(node, options) {
       rawSVGString: getSVGString(node)
     });
 
-    shapeGroup.setHasClippingMask(false);
     layers.push(svgLayer);
 
     return layers;

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -261,6 +261,7 @@ export default function nodeToSketchLayers(node, options) {
       rawSVGString: getSVGString(node)
     });
 
+    shapeGroup.setHasClippingMask(false);
     layers.push(svgLayer);
 
     return layers;


### PR DESCRIPTION
Fixes #114

Before we got:
<img width="254" alt="screen shot 2018-06-15 at 11 50 39" src="https://user-images.githubusercontent.com/4272331/41462221-6cb8b114-7092-11e8-9201-708e1004b18c.png">

Now it would be:
<img width="256" alt="screen shot 2018-06-15 at 11 51 07" src="https://user-images.githubusercontent.com/4272331/41462247-7d818782-7092-11e8-8f98-ac2ef0cd5267.png">
