### PR TITLE
Add ‘Paste’ command to Sketch plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,6 +48,8 @@
     "NSMakeRect": false,
     "NSBundle": false,
     "MSSharedStyle": false,
-    "MSLayerGroup": false
+    "MSLayerGroup": false,
+    "NSPasteboard": false,
+    "NSPasteboardTypeString": false
   }
 }

--- a/asketch2sketch/asketch2sketch.js
+++ b/asketch2sketch/asketch2sketch.js
@@ -94,43 +94,14 @@ function addSharedColor(document, colorJSON) {
   assets.addColor(color);
 }
 
-export default function asketch2sketch(context) {
+export default function asketch2sketch(context, asketchFiles) {
   const document = context.document;
   const page = document.currentPage();
 
   let asketchDocument = null;
   let asketchPage = null;
 
-  const panel = NSOpenPanel.openPanel();
-
-  panel.setCanChooseDirectories(false);
-  panel.setCanChooseFiles(true);
-  panel.setAllowsMultipleSelection(true);
-  panel.setTitle('Choose *.asketch.json files');
-  panel.setPrompt('Choose');
-  panel.setAllowedFileTypes(['json']);
-
-  if (panel.runModal() !== NSModalResponseOK || panel.URLs().length === 0) {
-    return;
-  }
-
-  const urls = panel.URLs();
-
-  urls.forEach(url => {
-    const data = NSData.dataWithContentsOfURL(url);
-    const content = NSString.alloc().initWithData_encoding_(data, NSUTF8StringEncoding);
-
-    let asketchFile = null;
-
-    try {
-      asketchFile = JSON.parse(content);
-    } catch (e) {
-      const alert = NSAlert.alloc().init();
-
-      alert.setMessageText('File is not a valid JSON.');
-      alert.runModal();
-    }
-
+  asketchFiles.forEach(asketchFile => {
     if (asketchFile && asketchFile._class === 'document') {
       asketchDocument = asketchFile;
     } else if (asketchFile && asketchFile._class === 'page') {

--- a/asketch2sketch/importFiles.js
+++ b/asketch2sketch/importFiles.js
@@ -1,0 +1,38 @@
+import asketch2sketch from './asketch2sketch';
+
+export default function importFiles(context) {
+  const panel = NSOpenPanel.openPanel();
+
+  panel.setCanChooseDirectories(false);
+  panel.setCanChooseFiles(true);
+  panel.setAllowsMultipleSelection(true);
+  panel.setTitle('Choose *.asketch.json files');
+  panel.setPrompt('Choose');
+  panel.setAllowedFileTypes(['json']);
+
+  if (panel.runModal() !== NSModalResponseOK || panel.URLs().length === 0) {
+    return;
+  }
+
+  const urls = Array.from(panel.URLs());
+
+  const asketchFiles = urls.map(url => {
+    const data = NSData.dataWithContentsOfURL(url);
+    const content = NSString.alloc().initWithData_encoding_(data, NSUTF8StringEncoding);
+
+    let asketchFile = null;
+
+    try {
+      asketchFile = JSON.parse(content);
+    } catch (e) {
+      const alert = NSAlert.alloc().init();
+
+      alert.setMessageText('File is not valid JSON.');
+      alert.runModal();
+    }
+
+    return asketchFile;
+  });
+
+  asketch2sketch(context, asketchFiles);
+}

--- a/asketch2sketch/manifest.json
+++ b/asketch2sketch/manifest.json
@@ -4,16 +4,25 @@
   "icon": "icon.png",
   "commands": [
     {
-      "name": "From *Almost* Sketch to Sketch",
-      "identifier": "asketch2sketch",
-      "script": "./asketch2sketch.js"
+      "name": "Import file(s)...",
+      "identifier": "importFiles",
+      "script": "./importFiles.js"
+    },
+    {
+      "name": "Paste",
+      "identifier": "paste",
+      "script": "./paste.js"
     }
   ],
   "menu": {
     "isRoot": true,
     "title": "output",
-    "items": [
-      "asketch2sketch"
-    ]
+    "items": [{
+      "title": "From *Almost* Sketch to Sketch",
+      "items": [
+        "importFiles",
+        "paste"
+      ]
+    }]
   }
 }

--- a/asketch2sketch/paste.js
+++ b/asketch2sketch/paste.js
@@ -1,0 +1,22 @@
+import asketch2sketch from './asketch2sketch';
+
+export default function paste(context) {
+  const clipboardContent = NSPasteboard.generalPasteboard().stringForType(NSPasteboardTypeString);
+
+  let clipboardJson = null;
+
+  try {
+    clipboardJson = JSON.parse(clipboardContent);
+  } catch (e) {
+    const alert = NSAlert.alloc().init();
+
+    alert.setMessageText('Clipboard content is not valid JSON.');
+    alert.runModal();
+
+    return;
+  }
+
+  const asketchFiles = Array.isArray(clipboardJson) ? clipboardJson : [clipboardJson];
+
+  asketch2sketch(context, asketchFiles);
+}


### PR DESCRIPTION
<img width="496" alt="screen shot 2018-07-05 at 11 35 38 am" src="https://user-images.githubusercontent.com/696693/42298118-912e1222-8047-11e8-8ce6-48a7470a4bca.png">

## tl;dr

This adds `Plugins > From *Almost* Sketch to Sketch > Paste`, enabling dynamic creation of JSON content in a browser environment, which can then be copied and pasted into Sketch.

The expected format is a JSON string containing a single object (the equivalent of a single file) or an array of objects (multiple files).

## Example usage

On a properly-configured style guide site, you could generate the desired component(s) and click a "Copy to Sketch" button. This would then run html-sketchapp directly in your browser and add it to your clipboard.

In Sketch, you would then run `Plugins > From *Almost* Sketch to Sketch > Paste`. From this point, the user experience is exactly the same as opening JSON files from disk.

Of course, there are other workflows that this unlocks, but this would be the most obvious.

## Why?

At [SEEK](https://github.com/seek-oss), we have a React-based [style guide](https://github.com/seek-oss/seek-style-guide) which we convert into a Sketch library with html-sketchapp (via [html-sketchapp-cli](https://github.com/seek-oss/html-sketchapp-cli)).

Obviously, it's been incredibly useful for us, and works *really* well in most scenarios. (Thank you so much for your work on this project, we're huge fans 👏👏👏)

However, we're starting to run into a few issues that are caused by having a purely static Sketch library.

- Some of our components have many options, which creates a combinatorial explosion of possible states, e.g. our [TextField component](https://seek-oss.github.io/seek-style-guide/textfield). It's simply not feasible to provide every possible state as a separate symbol without harming the simplicity and usability of the Sketch library.
- Some components are designed to be siblings, where the size of each component affects the layout of the entire group, e.g. our [Pill component](https://seek-oss.github.io/seek-style-guide/pill). Even if we get symbol resizing rules correct, symbol overrides fail to properly adjust the layout of surrounding components like it does in a browser environment.
- Overrides on the generated Sketch symbols are quite limited, and we often run into problems with the way Sketch resizes them when text content is modified. Proper support for Sketch's resizing rules is definitely improving, but unless Sketch supports the same layout engine as the browser, we're always going to run into issues.

So, in certain scenarios, we'd much prefer to let the browser do the work of dynamically generating and laying-out our components before committing to Sketch, rather than trying to magically turn Sketch into a browser.

## How?

I've updated the Sketch plugin so that it's no longer a single menu item, but a nested menu containing "Import file(s)..." (the existing plugin behaviour) and "Paste".

I've refactored the code so that the existing `asketch2sketch.js` is now shared functionality across both commands. Instead of opening the file dialog, it now expects you to provide an array of pre-parsed asketch files.

Each command (`importFiles.js`, `paste.js`) now loads and parses the JSON before providing it to `asketch2sketch.js` for processing.

When pasting, the expected format is JSON containing a single object (the equivalent of a single file) or an array of objects (multiple files). Otherwise, the format is exactly the same as what we see on disk.

## Trying it out

Once you've checked out this branch, built the plugin and installed it, you can try copying and pasting the contents of the JSON files in the `e2e/expected` folder.