### PR TITLE
Fix svgLayer

### DIFF
--- a/asketch2sketch/asketch2sketch.js
+++ b/asketch2sketch/asketch2sketch.js
@@ -74,10 +74,16 @@ function addSharedTextStyle(document, style) {
   if (container.addSharedStyleWithName_firstInstance) {
     container.addSharedStyleWithName_firstInstance(style.name, fromSJSONDictionary(style.value));
   } else {
-    // addSharedStyleWithName_firstInstance was removed in Sketch 50
-    const s = MSSharedStyle.alloc().initWithName_firstInstance(style.name, fromSJSONDictionary(style.value));
+    // thx airbnb :)
+    let sharedStyle;
+    const allocator = MSSharedStyle.alloc();
 
-    container.addSharedObject(s);
+    if (allocator.initWithName_firstInstance) {
+      sharedStyle = allocator.initWithName_firstInstance(style.name, fromSJSONDictionary(style.value));
+    } else {
+      sharedStyle = allocator.initWithName_style(style.name, fromSJSONDictionary(style.value));
+    }
+    container.addSharedObject(sharedStyle);
   }
 }
 

--- a/asketch2sketch/helpers/fixSVG.js
+++ b/asketch2sketch/helpers/fixSVG.js
@@ -19,7 +19,7 @@ function makeNativeSVGLayer(layer) {
     return null;
   }
 
-  while (svgLayer && svgLayer.layers && svgLayer.layers().length === 1 && svgLayer.class() instanceof MSLayerGroup) {
+  while (svgLayer.class() instanceof MSLayerGroup && svgLayer.layers().length === 1) {
     svgLayer = svgLayer.layers()[0];
   }
 

--- a/asketch2sketch/helpers/fixSVG.js
+++ b/asketch2sketch/helpers/fixSVG.js
@@ -19,7 +19,7 @@ function makeNativeSVGLayer(layer) {
     return null;
   }
 
-  while (svgLayer.layers().length === 1 && svgLayer.class() instanceof MSLayerGroup) {
+  while (svgLayer && svgLayer.layers && svgLayer.layers().length === 1 && svgLayer.class() instanceof MSLayerGroup) {
     svgLayer = svgLayer.layers()[0];
   }
 

--- a/html2asketch/model/base.js
+++ b/html2asketch/model/base.js
@@ -12,6 +12,7 @@ class Base {
     this._userInfo = null;
     this.setResizingConstraint(RESIZING_CONSTRAINTS.NONE);
     this.setHasClippingMask(false);
+    this.setHasClickThrough(false);
   }
 
   setFixedWidthAndHeight() {
@@ -54,6 +55,10 @@ class Base {
 
   setHasClippingMask(hasClippingMask) {
     this._hasClippingMask = hasClippingMask;
+  }
+
+  setHasClickThrough(hasClickThrough) {
+    this._hasClickThrough = hasClickThrough;
   }
 
   toJSON() {

--- a/html2asketch/model/base.js
+++ b/html2asketch/model/base.js
@@ -12,7 +12,6 @@ class Base {
     this._userInfo = null;
     this.setResizingConstraint(RESIZING_CONSTRAINTS.NONE);
     this.setHasClippingMask(false);
-    this.setHasClickThrough(false);
   }
 
   setFixedWidthAndHeight() {
@@ -55,10 +54,6 @@ class Base {
 
   setHasClippingMask(hasClippingMask) {
     this._hasClippingMask = hasClippingMask;
-  }
-
-  setHasClickThrough(hasClickThrough) {
-    this._hasClickThrough = hasClickThrough;
   }
 
   toJSON() {


### PR DESCRIPTION
Changes after update of Sketch to version 52
Two main changes:
1. Support shared styles, based on:
https://github.com/airbnb/react-sketchapp/commit/9f592639b620181ba80a2d19d5f7bbac1901ed3c
2. Adjustment in groups removal for SVG, make sure that there are `svgLayer` and `svgLayer.layers`