### PR TITLE
Custom IDs for library updates

### DIFF
--- a/html2asketch/model/artboard.js
+++ b/html2asketch/model/artboard.js
@@ -2,8 +2,8 @@ import Base from './base';
 
 class Artboard extends Base {
 
-  constructor({x, y, width, height}) {
-    super();
+  constructor({x, y, width, height, id}) {
+    super({id});
     this._class = 'artboard';
     this._x = x;
     this._y = y;

--- a/html2asketch/model/base.js
+++ b/html2asketch/model/base.js
@@ -26,7 +26,7 @@ class Base {
     return this._objectID;
   }
 
-  setId(id) {
+  setObjectID(id) {
     this._objectID = id;
   }
 

--- a/html2asketch/model/base.js
+++ b/html2asketch/model/base.js
@@ -3,11 +3,11 @@ import {generateID, RESIZING_CONSTRAINTS, calculateResizingConstraintValue} from
 const DEFAULT_USER_INFO_SCOPE = 'html-sketchapp';
 
 class Base {
-  constructor() {
+  constructor({ id } = {}) {
     this._class = null;
     this._layers = [];
     this._style = null;
-    this._objectID = generateID();
+    this._objectID = id || generateID();
     this._name = '';
     this._userInfo = null;
     this.setResizingConstraint(RESIZING_CONSTRAINTS.NONE);
@@ -24,6 +24,10 @@ class Base {
 
   getID() {
     return this._objectID;
+  }
+
+  setId(id) {
+    this._objectID = id;
   }
 
   // scope defines which Sketch plugin will have access to provided data via Settings.setLayerSettingForKey

--- a/html2asketch/model/base.js
+++ b/html2asketch/model/base.js
@@ -3,7 +3,7 @@ import {generateID, RESIZING_CONSTRAINTS, calculateResizingConstraintValue} from
 const DEFAULT_USER_INFO_SCOPE = 'html-sketchapp';
 
 class Base {
-  constructor({ id } = {}) {
+  constructor({id} = {}) {
     this._class = null;
     this._layers = [];
     this._style = null;

--- a/html2asketch/model/bitmap.js
+++ b/html2asketch/model/bitmap.js
@@ -2,8 +2,8 @@ import Base from './base';
 import {generateID} from '../helpers/utils';
 
 class Bitmap extends Base {
-  constructor({url, x, y, width, height}) {
-    super();
+  constructor({url, x, y, width, height, id}) {
+    super({id});
     this._class = 'bitmap';
     this._url = url;
     this._x = x;

--- a/html2asketch/model/document.js
+++ b/html2asketch/model/document.js
@@ -29,7 +29,7 @@ class Document {
     this._name = name;
   }
 
-  setId(id) {
+  setObjectID(id) {
     this._objectID = id;
   }
 

--- a/html2asketch/model/document.js
+++ b/html2asketch/model/document.js
@@ -8,10 +8,10 @@ function pageToPageReference(page) {
   };
 }
 
-function textStyleToSharedStyle(textLayer) {
+function textStyleToSharedStyle(textLayer, id) {
   return {
     '_class': 'sharedStyle',
-    'do_objectID': generateID(),
+    'do_objectID': id || generateID(),
     name: textLayer._name,
     'style': textLayer._style.toJSON()
   };
@@ -29,12 +29,16 @@ class Document {
     this._name = name;
   }
 
+  setId(id) {
+    this._objectID = id;
+  }
+
   addPage(page) {
     this._pages.push(page);
   }
 
-  addTextStyle(textLayer) {
-    this._textStyles.push(textStyleToSharedStyle(textLayer));
+  addTextStyle(textLayer, id) {
+    this._textStyles.push(textStyleToSharedStyle(textLayer, id));
   }
 
   addColor(color) {

--- a/html2asketch/model/group.js
+++ b/html2asketch/model/group.js
@@ -1,8 +1,8 @@
 import Base from './base';
 
 class Group extends Base {
-  constructor({x, y, width, height}) {
-    super();
+  constructor({x, y, width, height, id}) {
+    super({id});
     this._class = 'group';
     this._x = x;
     this._y = y;

--- a/html2asketch/model/page.js
+++ b/html2asketch/model/page.js
@@ -2,8 +2,8 @@ import Base from './base';
 
 class Page extends Base {
 
-  constructor({width, height}) {
-    super();
+  constructor({width, height, id}) {
+    super({id});
     this._class = 'page';
     this._width = width;
     this._height = height;

--- a/html2asketch/model/rectangle.js
+++ b/html2asketch/model/rectangle.js
@@ -1,8 +1,8 @@
 import Base from './base';
 
 class Rectangle extends Base {
-  constructor({width, height, cornerRadius = {topLeft: 0, bottomLeft: 0, topRight: 0, bottomRight: 0}}) {
-    super();
+  constructor({width, height, cornerRadius = {topLeft: 0, bottomLeft: 0, topRight: 0, bottomRight: 0}, id}) {
+    super({id});
     this._class = 'rectangle';
     this._width = width;
     this._height = height;

--- a/html2asketch/model/shapeGroup.js
+++ b/html2asketch/model/shapeGroup.js
@@ -1,8 +1,8 @@
 import Base from './base';
 
 class ShapeGroup extends Base {
-  constructor({x, y, width, height}) {
-    super();
+  constructor({x, y, width, height, id}) {
+    super({id});
     this._class = 'shapeGroup';
     this._width = width;
     this._height = height;

--- a/html2asketch/model/svg.js
+++ b/html2asketch/model/svg.js
@@ -1,8 +1,8 @@
 import Base from './base';
 
 class SVG extends Base {
-  constructor({x, y, width, height, rawSVGString}) {
-    super();
+  constructor({x, y, width, height, rawSVGString, id}) {
+    super({id});
     this._rawSVGString = rawSVGString;
     this._width = width;
     this._height = height;

--- a/html2asketch/model/symbolInstance.js
+++ b/html2asketch/model/symbolInstance.js
@@ -1,8 +1,8 @@
 import Base from './base';
 
 class SymbolInstance extends Base {
-  constructor({x, y, width, height, symbolID}) {
-    super();
+  constructor({x, y, width, height, symbolID, id}) {
+    super({id});
     this._class = 'symbolInstance';
     this._x = x;
     this._y = y;

--- a/html2asketch/model/symbolInstance.js
+++ b/html2asketch/model/symbolInstance.js
@@ -11,6 +11,10 @@ class SymbolInstance extends Base {
     this._symbolID = symbolID;
   }
 
+  setId(id) {
+    this._symbolID = id;
+  }
+
   toJSON() {
     const obj = super.toJSON();
 

--- a/html2asketch/model/symbolMaster.js
+++ b/html2asketch/model/symbolMaster.js
@@ -14,6 +14,7 @@ class SymbolMaster extends Base {
   }
 
   setId(id) {
+    super.setId(id);
     this._symbolID = id;
   }
 

--- a/html2asketch/model/symbolMaster.js
+++ b/html2asketch/model/symbolMaster.js
@@ -3,8 +3,8 @@ import Base from './base';
 import SymbolInstance from './symbolInstance';
 
 class SymbolMaster extends Base {
-  constructor({x, y, width = null, height = null}) {
-    super();
+  constructor({x, y, width = null, height = null, id}) {
+    super({id});
     this._class = 'symbolMaster';
     this._x = x;
     this._y = y;
@@ -14,7 +14,6 @@ class SymbolMaster extends Base {
   }
 
   setId(id) {
-    super.setId(id);
     this._symbolID = id;
   }
 

--- a/html2asketch/model/text.js
+++ b/html2asketch/model/text.js
@@ -2,8 +2,8 @@ import Base from './base';
 import {RESIZING_CONSTRAINTS} from '../helpers/utils';
 
 class Text extends Base {
-  constructor({x, y, width, height, text, style, multiline}) {
-    super();
+  constructor({x, y, width, height, text, style, multiline, id}) {
+    super({id});
     this._class = 'text';
     this._x = x;
     this._y = y;

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -322,7 +322,18 @@ export default function nodeToSketchLayers(node, options) {
 
       const textValue = fixWhiteSpace(textNode.nodeValue, whiteSpace);
 
+      let id;
+
+      if (textNode.parentNode && textNode.parentNode.dataset) {
+        const {sketchId, sketchText} = textNode.parentNode.dataset;
+
+        if (sketchId || sketchText) {
+          id = `text:${sketchId || sketchText}`;
+        }
+      }
+
       const text = new Text({
+        id,
         x: textBCR.left,
         y: textBCR.top + fixY,
         width: textBCR.right - textBCR.left,

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -322,18 +322,7 @@ export default function nodeToSketchLayers(node, options) {
 
       const textValue = fixWhiteSpace(textNode.nodeValue, whiteSpace);
 
-      let id;
-
-      if (textNode.parentNode && textNode.parentNode.dataset) {
-        const {sketchId, sketchText} = textNode.parentNode.dataset;
-
-        if (sketchId || sketchText) {
-          id = `text:${sketchId || sketchText}`;
-        }
-      }
-
       const text = new Text({
-        id,
         x: textBCR.left,
         y: textBCR.top + fixY,
         width: textBCR.right - textBCR.left,
@@ -342,6 +331,10 @@ export default function nodeToSketchLayers(node, options) {
         style: textStyle,
         multiline: numberOfLines > 1
       });
+
+      if (options && options.onTextGenerate) {
+        options.onTextGenerate({text, node: textNode.parentNode});
+      }
 
       layers.push(text);
     });

--- a/html2asketch/nodeToSketchLayers.js
+++ b/html2asketch/nodeToSketchLayers.js
@@ -333,7 +333,7 @@ export default function nodeToSketchLayers(node, options) {
       });
 
       if (options && options.onTextGenerate) {
-        options.onTextGenerate({text, node: textNode.parentNode});
+        options.onTextGenerate({layer: text, node: textNode});
       }
 
       layers.push(text);

--- a/tests/model/base.spec.js
+++ b/tests/model/base.spec.js
@@ -15,6 +15,13 @@ test('generates unique id', () => {
   expect(a.getID()).not.toBe(b.getID());
 });
 
+test('supports custom id', () => {
+  const a = new Base({id: 'test-id'});
+  const b = new Base({id: 'test-id'});
+
+  expect(a.getID()).toBe(b.getID());
+});
+
 test('can only be used when extended', () => {
   const a = new Base();
   const b = new Base2();
@@ -35,6 +42,15 @@ test('setName', () => {
   a.setName(name);
 
   expect(a.toJSON().name).toBe(name);
+});
+
+test('setObjectID', () => {
+  const a = new Base2();
+  const id = 'test/name-should-work';
+
+  a.setObjectID(id);
+
+  expect(a.toJSON().do_objectID).toBe(id);
 });
 
 test('addLayer', () => {

--- a/tests/model/symbolInstance.spec.js
+++ b/tests/model/symbolInstance.spec.js
@@ -7,6 +7,15 @@ test('sets symbolID', () => {
   expect(symbolInstance.toJSON().symbolID).toEqual(symbolID);
 });
 
+test('sets symbolID', () => {
+  const symbolID = 'pizza';
+  const symbolInstance = new SymbolInstance({x: 0, y: 0, width: 100, height: 100, symbolID: 'initial-id'});
+
+  symbolInstance.setId(symbolID);
+
+  expect(symbolInstance.toJSON().symbolID).toEqual(symbolID);
+});
+
 test('sets frame dimensions', () => {
   const symbolInstance = new SymbolInstance({x: 0, y: 50, width: 100, height: 150, symbolID: 'pizza'});
 

--- a/tests/model/symbolMaster.spec.js
+++ b/tests/model/symbolMaster.spec.js
@@ -7,6 +7,15 @@ test('toJSON() generates deterministic symbolIDs', () => {
   expect(symbolMaster.toJSON().symbolID).toEqual(symbolID);
 });
 
+test('symbolID can be set', () => {
+  const symbolMaster = new SymbolMaster({x: 200, y: 300});
+  const id = 'test-id';
+
+  symbolMaster.setId(id);
+
+  expect(symbolMaster.toJSON().symbolID).toEqual(id);
+});
+
 test('symbol instances have the same symbolID', () => {
   const symbolMaster = new SymbolMaster({x: 200, y: 300});
   const symbolInstance = symbolMaster.getSymbolInstance({x: 0, y: 0});


### PR DESCRIPTION
Adds `setId` methods that can be used to create permanent `object_ID`s for keeping existing Sketch libraries in sync between updates. https://github.com/seek-oss/html-sketchapp-cli/issues/18 #64 

Allows document, page, symbol master, symbol instance and shared style object IDs to be set.

Text custom ID example (to stop text overrides from resetting between updates):
```js
<Button data-sketch-id="buttons/default">
  Default Button
</Button>
```


```js
const layers = nodeToSketchLayers(node, {
  onTextGenerate: ({ text, node }) => {
    if (node && node.dataset) {
      const { sketchId } = node.dataset;

      if (sketchId) {
        text.setObjectID(`text:${sketchId}`);
      }
    }
  }
});
```
The dataset syntax (`data-sketch-id`) is inspired from `html-sketchapp-cli` for example purposes.

https://github.com/redsift/html-sketchapp/blob/8499ed81a07238b1c7f4ca138656d35b951899d7/html2asketch/nodeToSketchLayers.js#L327 - I'm wondering whether the text part is outside the scope of this repository and should live in `html-sketchapp-cli`? I feel it's best here though, adding middleware might be a bit bloated.