### PR TITLE
Adjustments in handling colors

### DIFF
--- a/asketch2sketch/asketch2sketch.js
+++ b/asketch2sketch/asketch2sketch.js
@@ -89,14 +89,14 @@ function addSharedTextStyle(document, style) {
 function removeSharedColors(document) {
   const assets = document.documentData().assets();
 
-  assets.removeAllColors();
+  assets.removeAllColorAssets();
 }
 
 function addSharedColor(document, colorJSON) {
   const assets = document.documentData().assets();
   const color = fromSJSONDictionary(colorJSON);
 
-  assets.addColor(color);
+  assets.addAsset(color);
 }
 
 export default function asketch2sketch(context, asketchFiles) {

--- a/asketch2sketch/asketch2sketch.js
+++ b/asketch2sketch/asketch2sketch.js
@@ -96,7 +96,7 @@ function addSharedColor(document, colorJSON) {
   const assets = document.documentData().assets();
   const color = fromSJSONDictionary(colorJSON);
 
-  assets.addAsset(color);
+  assets.addColorAsset(color);
 }
 
 export default function asketch2sketch(context, asketchFiles) {


### PR DESCRIPTION
Small adjustment after update of Sketch to version 53.1

According to changes https://github.com/abynim/Sketch-Headers/commit/98d0809fd1992efa197fbb553623c621f366ff7e#diff-ae506b960e30befce2ffd1334676d344

`removeAllColors` changed to `removeAllColorAssets`
`addColor` changed to `addColorAsset`

Fixes #160
