### PR TITLE
Bugfix - Adjust method to add asset and bump version

### DIFF
--- a/asketch2sketch/asketch2sketch.js
+++ b/asketch2sketch/asketch2sketch.js
@@ -96,7 +96,7 @@ function addSharedColor(document, colorJSON) {
   const assets = document.documentData().assets();
   const color = fromSJSONDictionary(colorJSON);
 
-  assets.addColorAsset(color);
+  assets.addAsset(color);
 }
 
 export default function asketch2sketch(context, asketchFiles) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainly/html-sketchapp",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainly/html-sketchapp",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "HTML to Sketch",
   "keywords": [
     "sketch",


### PR DESCRIPTION
As described in https://github.com/brainly/html-sketchapp/issues/154, I should have used `addAsset` method here.

Fixes #163